### PR TITLE
Resolve multi word graphql types correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql_rails (0.4.1)
+    graphql_rails (0.4.2)
       activesupport (>= 4)
       graphql (~> 1)
 
@@ -31,7 +31,7 @@ GEM
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     docile (1.3.0)
-    graphql (1.8.4)
+    graphql (1.9.3)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
@@ -105,4 +105,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/graphql_rails/type_parser.rb
+++ b/lib/graphql_rails/type_parser.rb
@@ -82,11 +82,11 @@ module GraphqlRails
     end
 
     def inner_type_name
-      unparsed_type.to_s.downcase.tr('[]!', '')
+      unparsed_type.to_s.tr('[]!', '')
     end
 
     def type_by_name
-      TYPE_MAPPING.fetch(inner_type_name) do
+      TYPE_MAPPING.fetch(inner_type_name.downcase) do
         dynamicly_defined_type || raise(
           UnknownTypeError,
           "Type #{unparsed_type.inspect} is not supported. Supported scalar types are: #{TYPE_MAPPING.keys}." \
@@ -96,7 +96,7 @@ module GraphqlRails
     end
 
     def dynamicly_defined_type
-      type_class = inner_type_name.capitalize.safe_constantize
+      type_class = inner_type_name.safe_constantize
       return unless type_class.respond_to?(:graphql)
 
       type_class.graphql.graphql_type

--- a/lib/graphql_rails/version.rb
+++ b/lib/graphql_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GraphqlRails
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/lib/graphql_rails/type_parser_spec.rb
+++ b/spec/lib/graphql_rails/type_parser_spec.rb
@@ -21,10 +21,10 @@ module GraphqlRails
       end
 
       context 'when model type is provided' do
-        let(:type) { 'Image' }
+        let(:type) { 'SomeImage' }
 
         it 'returns grapqhl type defined on that model' do
-          image = Object.const_set('Image', Class.new { include GraphqlRails::Model })
+          image = Object.const_set('SomeImage', Class.new { include GraphqlRails::Model })
           expect(call).to eq image.graphql.graphql_type
         end
       end


### PR DESCRIPTION
Currently, in controller, it's only possible to specify single word classes as return type, like `action(:create).returns('User')`, `action(:create).returns('Admin::Order')`, but not `action(:create).returns('SomeUser')`, `action(:create).returns('UserArea::ShopList')`. This PR fixes this issue