### PR TITLE
Execute hooks in controller context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-* Your contribution here.
+* Fixed controller action hooks context [@povilasjurcys](https://github.com/povilasjurcys).
 
 ## 0.5.0 (2019-04-03)
 

--- a/lib/graphql_rails/controller/action_hooks_runner.rb
+++ b/lib/graphql_rails/controller/action_hooks_runner.rb
@@ -9,10 +9,10 @@ module GraphqlRails
         @controller = controller
       end
 
-      def call
+      def call(&block)
         result = nil
         run_action_hooks(:before)
-        run_around_action_hooks { result = yield }
+        run_around_action_hooks { result = controller.instance_exec(&block) }
         run_action_hooks(:after)
         result
       end
@@ -42,7 +42,7 @@ module GraphqlRails
 
       def execute_hook(action_hook, &block)
         if action_hook.anonymous?
-          action_hook.action_proc.call(controller, *block)
+          controller.instance_exec(controller, *block, &action_hook.action_proc)
         else
           controller.send(action_hook.name, &block)
         end

--- a/spec/lib/graphql_rails/controller/action_hooks_runner_spec.rb
+++ b/spec/lib/graphql_rails/controller/action_hooks_runner_spec.rb
@@ -36,10 +36,14 @@ module GraphqlRails
       end
 
       describe '#call' do
-        context 'when no action is defined' do
-          it 'exectes given block' do
-            expect { |b| runner.call(&b) }.to yield_control
-          end
+        it 'executes block in controller context' do
+          instance = nil
+          runner.call { instance = self }
+          expect(instance).to be(controller)
+        end
+
+        it 'exectes given block' do
+          expect { |b| runner.call(&b) }.to yield_control
         end
 
         context 'when before actions are defined' do
@@ -101,6 +105,15 @@ module GraphqlRails
 
           it 'executes given block once' do
             expect { |b| runner.call(&b) }.to yield_control
+          end
+        end
+
+        context 'when anonymous hook is defined' do
+          it 'is executed in controller context' do
+            instance = nil
+            controller_configuration.add_action_hook(:before) { instance = self }
+            runner.call {}
+            expect(instance).to be(controller)
           end
         end
       end


### PR DESCRIPTION
Currently anonymous hooks (defined with block, and not with method name) are run in wrong context, so it's impossible to call controller methods. For example, this was impossible:

```
class MyController < GraphqlRails::Controller
  before_action do
    return if current_user.active?
    raise UserNotActiveError
  end

  def current_user
    # ...
  end
end
```