### PR TITLE
Add default router and QueryRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
+* Added: default router added. No need to assign value to constant on Router.draw
 
 ## [0.8.0] (2019-09-03)
 

--- a/lib/graphql_rails.rb
+++ b/lib/graphql_rails.rb
@@ -8,6 +8,7 @@ require 'graphql_rails/router'
 require 'graphql_rails/controller'
 require 'graphql_rails/attributes'
 require 'graphql_rails/decorator'
+require 'graphql_rails/query_runner'
 
 # wonders starts here
 module GraphqlRails

--- a/lib/graphql_rails/query_runner.rb
+++ b/lib/graphql_rails/query_runner.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module GraphqlRails
+  # executes GraphQL queries and returns json
+  class QueryRunner
+    require 'graphql_rails/router'
+    require 'graphql_rails/concerns/service'
+
+    include ::GraphqlRails::Service
+
+    def initialize(router: :default, params:, **schema_options)
+      @router_name = router
+      @params = params
+      @schema_options = schema_options
+    end
+
+    def call
+      router.graphql_schema.execute(
+        params[:query],
+        variables: variables,
+        operation_name: params[:operationName],
+        **schema_options
+      )
+    end
+
+    private
+
+    attr_reader :schema_options, :params, :router_name
+
+    def variables
+      ensure_hash(params[:variables])
+    end
+
+    def router
+      Router.routers[router_name]
+    end
+
+    def ensure_hash(ambiguous_param)
+      if ambiguous_param.blank?
+        {}
+      elsif ambiguous_param.is_a?(String)
+        ensure_hash(JSON.parse(ambiguous_param))
+      elsif kind_of_hash?(ambiguous_param)
+        ambiguous_param
+      else
+        raise ArgumentError, "Unexpected parameter: #{ambiguous_param.inspect}"
+      end
+    end
+
+    def kind_of_hash?(object)
+      return true if object.is_a?(Hash)
+
+      defined?(ActionController) &&
+        defined?(ActionController::Parameters) &&
+        object.is_a?(ActionController::Parameters)
+    end
+  end
+end

--- a/lib/graphql_rails/router/route.rb
+++ b/lib/graphql_rails/router/route.rb
@@ -26,10 +26,6 @@ module GraphqlRails
         on == :collection
       end
 
-      def member?
-        on == :member
-      end
-
       def function
         @function ||= Controller::ControllerFunction.from_route(self)
       end

--- a/spec/lib/graphql_rails/query_runner_spec.rb
+++ b/spec/lib/graphql_rails/query_runner_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module GraphqlRails
+  RSpec.describe QueryRunner do
+    class DummyQueryRunnerController < GraphqlRails::Controller
+      action(:do_something).permit(:val).returns(:string)
+
+      def do_something
+        params[:val] || 'OK'
+      end
+    end
+
+    subject(:query_runner) { described_class.new(params: params) }
+
+    let(:params) do
+      {
+        query: query,
+        variables: variables
+      }
+    end
+
+    let(:query) { 'query { doSomething }' }
+    let(:variables) { {} }
+
+    describe '#call' do
+      subject(:call) { query_runner.call }
+
+      before do
+        Router.draw do
+          query :do_something, to: 'graphql_rails/dummy_query_runner#do_something'
+        end
+      end
+
+      context 'when variables are not used' do
+        it 'returns correct json' do
+          result = call.to_h['data']['doSomething']
+          expect(result).to eq 'OK'
+        end
+      end
+
+      context 'when variables are used' do
+        let(:query) { 'query($val: String!) { doSomething(val: $val) }' }
+        let(:variables) { { val: 'success!' } }
+
+        context 'when variables are given as Hash' do
+          it 'returns correct json' do
+            result = call.to_h['data']['doSomething']
+            expect(result).to eq 'success!'
+          end
+        end
+
+        context 'when variables are given as JSON string' do
+          let(:variables) { { val: 'success!' }.to_json }
+
+          it 'returns correct json' do
+            result = call.to_h['data']['doSomething']
+            expect(result).to eq 'success!'
+          end
+        end
+
+        context 'when variables are given as unsupported type' do
+          let(:variables) { :unsupported }
+
+          it 'returns correct json' do
+            expect { call }.to raise_error('Unexpected parameter: :unsupported')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before do
+    GraphqlRails::Router.reload
+  end
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
This will allow us to remember routes which where defined with Router.draw.

`QueryRunner` uses this default router and allows to simplify rails side controller. It also opens possibility to test real requests in rspec

Solves #93