### PR TITLE
Remove default return type for controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
+*
+* Removed: `action.can_return_nil` was removed, because it does no affect anymore
+* Removed: default `action` model was removed. Now each action must have `returns` part
 * Added: default router added. No need to assign value to constant on Router.draw
 * Added: install generator. Now it's possible to generate boilerplate code
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ class Graphql::UsersController < GraphqlApplicationController
   # graphql requires to describe which attributes controller action accepts and which returns
   action(:change_user_password)
     .permit(:password!, :id!) # Bang (!) indicates that attribute is required
+    .returns('User!')
 
   def change_user_password
     user = User.find(params[:id])
@@ -81,7 +82,9 @@ class Graphql::UsersController < GraphqlApplicationController
     user # or SomeDecorator.new(user)
   end
 
-  action(:search).permit(search_fields!: SearchFieldsInput) # you can specify your own input fields
+  action(:search)
+    .permit(search_fields!: SearchFieldsInput) # you can specify your own input fields
+    .returns('[User!]!')
   def search
   end
 end
@@ -143,11 +146,13 @@ There are 3 helper methods:
 
 ```ruby
 class MyGraphqlController
+  action(:create_user).permit(:full_name, :email).returns(User)
+  action(:index).returns('String')
+
   def index
     "Called from index: #{params[:message]}"
   end
 
-  action(:create_user).permit(:full_name, :email)
   def create_user
     User.create!(params)
   end

--- a/docs/components/controller.md
+++ b/docs/components/controller.md
@@ -155,22 +155,6 @@ class OrderController < GraphqlRails::Controller
 end
 ```
 
-### *can_return_nil*
-
-By default it is expected that each controller action returns model or array of models. `nil` is not allowed. You can change that by adding `can_return_nil` like this:
-
-```ruby
-class UsersController < GraphqlRails::Controller
-  action(:show).permit(:email).can_return_nil
-
-  def show
-    user = User.find_by(email: params[:email])
-    return nil if user.blank?
-    user
-  end
-end
-```
-
 ### *paginated*
 
 You can mark collection action as `paginated`. In this case controller will return relay connection type and it will be possible to return only partial results. No need to do anything on controller side (you should always return full list of items)
@@ -203,7 +187,7 @@ end
 
 ### *returns*
 
-By default return type is determined by controller name. When you want to return some custom object, you can specify that with `returns` method:
+You must specify what each action will return. This is done with `returns` method:
 
 ```ruby
 class UsersController < GraphqlRails::Controller

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -28,11 +28,13 @@ There are 3 helper methods:
 
 ```ruby
 class MyGraphqlController
+  action(:create_user).permit(:full_name, :email).returns(User)
+  action(:index).returns('String')
+
   def index
     "Called from index: #{params[:message]}"
   end
 
-  action(:create_user).permit(:full_name, :email)
   def create_user
     User.create!(params)
   end

--- a/lib/graphql_rails/controller/action.rb
+++ b/lib/graphql_rails/controller/action.rb
@@ -9,14 +9,14 @@ module GraphqlRails
   class Controller
     # analyzes route and extracts controller action related data
     class Action
-      class MissingConfigurationError < GraphqlRails::Error; end
+      class DeprecatedDefaultModelError < GraphqlRails::Error; end
 
       def initialize(route)
         @route = route
       end
 
       def return_type
-        action_config.return_type || default_type
+        action_config.return_type || raise_deprecation_error
       end
 
       def arguments
@@ -39,37 +39,12 @@ module GraphqlRails
 
       attr_reader :route
 
-      def default_inner_return_type
-        raise_missing_return_type_error if model_graphql_type.nil?
-
-        if action_config.can_return_nil?
-          model_graphql_type
-        else
-          model_graphql_type.to_non_null_type
-        end
-      end
-
-      def raise_missing_return_type_error
-        error_message = \
-          "Return type for #{route.path.inspect} is not defined. " \
-          "To do so, add `action(:#{name}).returns(YourType)` in #{controller.name} " \
-          "or make sure that you have model named #{namespaced_model_name}"
-
-        raise MissingConfigurationError, error_message
-      end
-
-      def default_type
-        return default_collection_type if route.collection?
-
-        default_inner_return_type
-      end
-
-      def default_collection_type
-        if action_config.paginated?
-          action_model.graphql.connection_type
-        else
-          default_inner_return_type.to_list_type.to_non_null_type
-        end
+      def raise_deprecation_error
+        message = \
+          'Default return types are deprecated. ' \
+          "You need to set something like `action(:#{name}).returns('#{namespaced_model_name}')` " \
+          "for #{action_relative_path} action manualy"
+        raise DeprecatedDefaultModelError, message
       end
 
       def action_relative_path
@@ -88,36 +63,8 @@ module GraphqlRails
         @controller_name ||= action_relative_path.split('#').first
       end
 
-      def action_model
-        namespace = namespaced_model_name.split('::')
-        model_name = namespace.pop
-        model = nil
-
-        while model.nil? && !namespace.empty?
-          model = namespaced_model(namespace, model_name)
-          namespace.pop
-        end
-
-        model || namespaced_model(namespace, model_name)
-      end
-
-      def namespaced_model(namespace, model_name)
-        [namespace, model_name].join('::').constantize
-      rescue NameError => err
-        raise unless err.message.match?(/uninitialized constant/)
-
-        nil
-      end
-
       def namespaced_model_name
         namespaced_controller_name.singularize.classify
-      end
-
-      def model_graphql_type
-        return unless action_model
-        return unless action_model < GraphqlRails::Model
-
-        action_model.graphql.graphql_type
       end
     end
   end

--- a/lib/graphql_rails/controller/action_configuration.rb
+++ b/lib/graphql_rails/controller/action_configuration.rb
@@ -17,7 +17,6 @@ module GraphqlRails
       def initialize
         @attributes = {}
         @action_options = {}
-        @can_return_nil = false
       end
 
       def options(input_format:)
@@ -57,19 +56,10 @@ module GraphqlRails
         end
       end
 
-      def can_return_nil
-        @can_return_nil = true
-        self
-      end
-
       def returns(custom_return_type)
         @return_type = nil
         @custom_return_type = custom_return_type
         self
-      end
-
-      def can_return_nil?
-        @can_return_nil
       end
 
       def paginated?

--- a/spec/lib/graphql_rails/controller/action_spec.rb
+++ b/spec/lib/graphql_rails/controller/action_spec.rb
@@ -10,7 +10,7 @@ module GraphqlRails
     RSpec.describe Action do
       class CustomDummyUsersController < GraphqlRails::Controller; end
       class DummyUsersController < GraphqlRails::Controller
-        action(:show).returns(GraphQL::STRING_TYPE.to_non_null_type).can_return_nil
+        action(:show).returns(GraphQL::STRING_TYPE.to_non_null_type)
         action(:paginated_index).paginated
       end
 
@@ -49,69 +49,8 @@ module GraphqlRails
         end
 
         context 'when action configuration does not specify return type' do
-          context 'when controller has model' do
-            it 'generates type from controller model' do
-              expect(return_type).to eq(DummyUser.graphql.graphql_type.to_non_null_type)
-            end
-
-            context 'when return type is for collection route' do
-              let(:route_type) { :collection }
-
-              context 'when action is paginated' do
-                let(:action_name) { 'paginated_index' }
-
-                it 'returns connection' do
-                  expect(return_type.to_s).to eq 'DummyUserConnection'
-                end
-              end
-
-              context 'when action is not paginated' do
-                it 'returns list type' do
-                  expect(return_type).to be_list
-                end
-
-                it 'returns non null type' do
-                  expect(return_type).to be_non_null
-                end
-              end
-
-              context 'when exits many collection action' do
-                subject(:action2) { described_class.new(route2) }
-
-                let(:route2) do
-                  Router::QueryRoute.new(
-                    :dummy_users,
-                    to: route_path2,
-                    module: 'graphql_rails/controller',
-                    on: route_type
-                  )
-                end
-                let(:route_path) { "#{controller_name}##{action_name2}" }
-                let(:action_name2) { 'paginated_new_action' }
-
-                it 'returns non null type' do
-                  expect(return_type).to be_non_null
-                end
-              end
-            end
-
-            context 'when return type is for member route' do
-              it 'returns singular type' do
-                expect(return_type).not_to be_list
-              end
-
-              it 'returns non null type' do
-                expect(return_type).to be_non_null
-              end
-            end
-          end
-
-          context 'when controller does not have model' do
-            let(:controller_name) { 'custom_dummy_users' }
-
-            it 'raises exception' do
-              expect { action.return_type }.to raise_error(Action::MissingConfigurationError)
-            end
+          it 'raises deprecation message' do
+            expect { return_type }.to raise_error(Action::DeprecatedDefaultModelError)
           end
         end
       end

--- a/spec/lib/graphql_rails/controller/controller_function_spec.rb
+++ b/spec/lib/graphql_rails/controller/controller_function_spec.rb
@@ -19,7 +19,7 @@ module GraphqlRails
           end
 
           class UsersController < GraphqlRails::Controller
-            action(:show).permit(:name!)
+            action(:show).permit(:name!).returns(User.to_s)
             def show
               render 'show:OK'
             end
@@ -62,13 +62,11 @@ module GraphqlRails
           instance_double(
             ActionConfiguration,
             return_type: action_config_return_type,
-            description: nil,
-            can_return_nil?: can_return_nil
+            description: nil
           )
         end
 
         let(:action_config_return_type) { nil }
-        let(:can_return_nil) { false }
 
         before do
           action = Action.new(route)
@@ -80,34 +78,14 @@ module GraphqlRails
         context 'when action has specified type' do
           let(:action_config_return_type) { GraphQL::STRING_TYPE }
 
-          context 'when not allowed to return nil' do
-            it 'ignores "can_return_nil" options and returns original type' do
-              expect(type).to eq action_config.return_type
-            end
-          end
-
-          context 'when allowed to return nil' do
-            let(:can_return_nil) { true }
-
-            it 'ignores "can_return_nil" options and returns original type' do
-              expect(type).to eq action_config.return_type
-            end
+          it 'returns specified type' do
+            expect(type).to eq action_config.return_type
           end
         end
 
         context 'when action did not specify any return type' do
-          context 'when not allowed to return nil' do
-            it 'returns type from controller related mode with non null requirement' do
-              expect(type).to eq Dummy::Foo::User.graphql.graphql_type.to_non_null_type
-            end
-          end
-
-          context 'when allowed to return nil' do
-            let(:can_return_nil) { true }
-
-            it 'returns type from controller related model' do
-              expect(type).to eq Dummy::Foo::User.graphql.graphql_type
-            end
+          it 'raises deprecation message' do
+            expect { type }.to raise_error(Action::DeprecatedDefaultModelError)
           end
         end
       end


### PR DESCRIPTION
Currently when controller action does not specify return type then this type is guessed based on controller name. For example:

```
class UsersController < GraphqlRails::Controller
  action(:index)
  action(:show)
end
```

for `index` action it will set return type `[Users!]!` and for show action it will set `User!`.

This model guessing feature is a little bit too magical and also makes GraphqlRails code more complicated then it should.

This PR forces to specify return type for each action and also removes `can_return_nil` method because it affected only guessed types. In other words `action(:index)` will raise exception complaining we should replace it with `action(:index).returns(Something)`