### PR TITLE
Do not share options config between actions

### DIFF
--- a/lib/graphql_rails/controller/action_configuration.rb
+++ b/lib/graphql_rails/controller/action_configuration.rb
@@ -14,6 +14,8 @@ module GraphqlRails
       def initialize_copy(other)
         super
         @attributes = other.instance_variable_get(:@attributes).dup.transform_values(&:dup)
+        @action_options = other.instance_variable_get(:@action_options).dup.transform_values(&:dup)
+        @pagination_options = other.instance_variable_get(:@pagination_options)&.dup&.transform_values(&:dup)
       end
 
       def initialize
@@ -21,8 +23,12 @@ module GraphqlRails
         @action_options = {}
       end
 
-      def options(input_format:)
-        @action_options[:input_format] = input_format
+      def options(action_options = nil)
+        @options ||= {}
+        return @options if action_options.nil?
+
+        @options[:input_format] = action_options[:input_format] if action_options[:input_format]
+
         self
       end
 
@@ -37,7 +43,7 @@ module GraphqlRails
 
         attributes[field_name] = Attributes::InputAttribute.new(
           name.to_s, type,
-          options: action_options.merge(options),
+          options: self.options.merge(options),
           **input_options
         )
         self
@@ -99,7 +105,7 @@ module GraphqlRails
 
       private
 
-      attr_reader :custom_return_type, :action_options
+      attr_reader :custom_return_type
 
       def raise_missing_config_error
         error_message = \

--- a/spec/lib/graphql_rails/controller/configuration_spec.rb
+++ b/spec/lib/graphql_rails/controller/configuration_spec.rb
@@ -78,6 +78,30 @@ module GraphqlRails
           expect(configuration.default_action.attributes.keys).to match_array(%w[default])
         end
       end
+
+      context 'when options was used' do
+        let(:define_actions) do
+          configuration.action(:some_method).options(input_format: :original).permit(:id)
+          configuration.action(:some_other_method).permit(:id, :name)
+        end
+
+        it 'sets options only for given action', :aggregate_failures do
+          expect(configuration.action(:some_method).options).to eq(input_format: :original)
+          expect(configuration.action(:some_other_method).options).to eq({})
+        end
+      end
+
+      context 'when pagination options was set' do
+        let(:define_actions) do
+          configuration.action(:some_method).paginated(max_page_size: 200).permit(:id)
+          configuration.action(:some_other_method).permit(:id, :name)
+        end
+
+        it 'sets options only for given action', :aggregate_failures do
+          expect(configuration.action(:some_method).pagination_options).to eq(max_page_size: 200)
+          expect(configuration.action(:some_other_method).pagination_options).to be_nil
+        end
+      end
     end
 
     describe '#model' do


### PR DESCRIPTION
Currently we have a bug when we use multiple action for same controller, and one of action has `options` part. Example:

```ruby
class MyController < GraphqlRails::Controller
  action(:something).options(input_format: :original)
  action(:something_else)
end
```

the problem is that `action(:something_else)` will also inherits `.options(input_format: :original)`

This PR fixes this issue and also makes `options` method more consistent with other config methods
