### PR TITLE
Refs #148: Allow changing method name format fom model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
+* Added: `options` argument to model level attribute. Allows disabling automatic camelCase
+
 ## [1.0.0](2020-02-07)
 
 * Added: "required" and "optional" flags for attribute

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -110,6 +110,21 @@ class User
 end
 ```
 
+### attribute.camelize
+
+Allows disabling or enabling `camelCase` convertions. Defaults to `true`, meaning all of your attributes will be converted into `camelCase`.
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    c.attribute :first_name # will be accessible as firstName from client side
+    c.attribute :first_name, camelize: true # will be accessible as firstName from client side
+    c.attribute :first_name, camelize: false # will be accessible as first_name from client side
+  end
+end
+
 ### attribute.permit
 
 To define attributes which are accepted by each model method, you need to call `permit` method, like this:

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -110,9 +110,11 @@ class User
 end
 ```
 
-### attribute.camelize
+### attribute.options
 
-Allows disabling or enabling `camelCase` convertions. Defaults to `true`, meaning all of your attributes will be converted into `camelCase`.
+Allows passing options to attribute definition. Available options:
+
+* `attribute_name_format` - if `:original` value is passed, it will not camelCase attribute name.
 
 ```ruby
 class User
@@ -120,8 +122,7 @@ class User
 
   graphql do |c|
     c.attribute :first_name # will be accessible as firstName from client side
-    c.attribute :first_name, camelize: true # will be accessible as firstName from client side
-    c.attribute :first_name, camelize: false # will be accessible as first_name from client side
+    c.attribute :first_name, options: { attribute_name_format: :original } # will be accessible as first_name from client side
   end
 end
 

--- a/lib/graphql_rails/attributes/attributable.rb
+++ b/lib/graphql_rails/attributes/attributable.rb
@@ -46,12 +46,6 @@ module GraphqlRails
         !required?
       end
 
-      protected
-
-      def options
-        {}
-      end
-
       private
 
       def type_parser

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -85,6 +85,8 @@ module GraphqlRails
 
       attr_reader :initial_type, :initial_name
 
+      private
+
       def camelize?
         @camelize == true
       end

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -13,9 +13,10 @@ module GraphqlRails
 
       attr_reader :attributes
 
-      def initialize(name, type = nil, description: nil, property: name, required: nil)
+      def initialize(name, type = nil, description: nil, property: name, required: nil, camelize: true)
         @initial_type = type
         @initial_name = name
+        @camelize = camelize
         @description = description
         @property = property.to_s
         @required = required
@@ -43,6 +44,13 @@ module GraphqlRails
         self
       end
 
+      def camelize(new_camelize = nil)
+        return @camelize if new_camelize.nil?
+
+        @camelize = new_camelize
+        self
+      end
+
       def field_args
         [
           field_name,
@@ -50,7 +58,8 @@ module GraphqlRails
           *description,
           {
             method: property.to_sym,
-            null: optional?
+            null: optional?,
+            camelize: !!camelize
           }
         ]
       end
@@ -64,6 +73,12 @@ module GraphqlRails
             required: required?
           }
         ]
+      end
+
+      def options
+        {}.tap do |it|
+          it[:input_format] = :original unless @camelize
+        end
       end
 
       protected

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -13,10 +13,10 @@ module GraphqlRails
 
       attr_reader :attributes
 
-      def initialize(name, type = nil, description: nil, property: name, required: nil, camelize: true)
+      def initialize(name, type = nil, description: nil, property: name, required: nil, options: {})
         @initial_type = type
         @initial_name = name
-        @camelize = camelize
+        @options = options
         @description = description
         @property = property.to_s
         @required = required
@@ -44,10 +44,10 @@ module GraphqlRails
         self
       end
 
-      def camelize(new_camelize = nil)
-        return @camelize if new_camelize.nil?
+      def options(new_options = {})
+        return @options if new_options.blank?
 
-        @camelize = new_camelize
+        @options = new_options
         self
       end
 
@@ -58,8 +58,7 @@ module GraphqlRails
           *description,
           {
             method: property.to_sym,
-            null: optional?,
-            camelize: camelize?
+            null: optional?
           }
         ]
       end
@@ -75,21 +74,9 @@ module GraphqlRails
         ]
       end
 
-      def options
-        {}.tap do |it|
-          it[:input_format] = :original unless @camelize
-        end
-      end
-
       protected
 
       attr_reader :initial_type, :initial_name
-
-      private
-
-      def camelize?
-        @camelize == true
-      end
     end
   end
 end

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -59,7 +59,7 @@ module GraphqlRails
           {
             method: property.to_sym,
             null: optional?,
-            camelize: !!camelize
+            camelize: camelize?
           }
         ]
       end
@@ -84,6 +84,10 @@ module GraphqlRails
       protected
 
       attr_reader :initial_type, :initial_name
+
+      def camelize?
+        @camelize == true
+      end
     end
   end
 end

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -13,6 +13,7 @@ module GraphqlRails
 
       attr_reader :attributes
 
+      # rubocop:disable Metrics/ParameterLists
       def initialize(name, type = nil, description: nil, property: name, required: nil, options: {})
         @initial_type = type
         @initial_name = name
@@ -22,6 +23,7 @@ module GraphqlRails
         @required = required
         @attributes ||= {}
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def type(new_type = nil)
         return @initial_type if new_type.nil?

--- a/lib/graphql_rails/attributes/attribute_name_parser.rb
+++ b/lib/graphql_rails/attributes/attribute_name_parser.rb
@@ -44,7 +44,7 @@ module GraphqlRails
       attr_reader :options
 
       def original_format?
-        options[:input_format] == :original
+        options[:input_format] == :original || options[:attribute_name_format] == :original
       end
 
       def preprocesed_name

--- a/spec/lib/graphql_rails/attributes/attribute_name_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_name_parser_spec.rb
@@ -22,8 +22,16 @@ module GraphqlRails
             end
           end
 
-          context 'with original format option' do
+          context 'with original input format option' do
             let(:options) { { input_format: :original } }
+
+            it 'keeps original format' do
+              expect(field_name).to eq(name)
+            end
+          end
+
+          context 'with original attribute name format option' do
+            let(:options) { { attribute_name_format: :original } }
 
             it 'keeps original format' do
               expect(field_name).to eq(name)

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -19,7 +19,7 @@ module GraphqlRails
 
       describe '#options' do
         it 'sets options correctly' do
-          expect { attribute.options({ new_option: true }) }.to change(attribute, :options).to({ new_option: true })
+          expect { attribute.options(new_option: true) }.to change(attribute, :options).to({ new_option: true })
         end
       end
 

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -58,7 +58,7 @@ module GraphqlRails
 
         context 'when camelize is false' do
           let(:camelize) { false }
-  
+
           it 'specifies :original input formatter' do
             expect(attribute.options[:input_format]).to eq :original
           end

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -5,11 +5,11 @@ require 'spec_helper'
 module GraphqlRails
   module Attributes
     RSpec.describe Attribute do
-      subject(:attribute) { described_class.new(name, type, camelize: camelize) }
+      subject(:attribute) { described_class.new(name, type, options: options) }
 
       let(:type) { 'String!' }
       let(:name) { 'full_name' }
-      let(:camelize) { true }
+      let(:options) { {} }
 
       describe '#property' do
         it 'sets property correctly' do
@@ -17,9 +17,9 @@ module GraphqlRails
         end
       end
 
-      describe '#camelize' do
-        it 'sets camelize flag correctly' do
-          expect { attribute.camelize(false) }.to change(attribute, :camelize).to(false)
+      describe '#options' do
+        it 'sets options correctly' do
+          expect { attribute.options({ new_option: true }) }.to change(attribute, :options).to({ new_option: true })
         end
       end
 
@@ -46,22 +46,6 @@ module GraphqlRails
       describe '#type' do
         it 'sets type correctly' do
           expect { attribute.type(:int!) }.to change(attribute, :type).to(:int!)
-        end
-      end
-
-      describe '#options' do
-        context 'when camelize is true' do
-          it 'does not specify input format' do
-            expect(attribute.options[:input_format]).to be_nil
-          end
-        end
-
-        context 'when camelize is false' do
-          let(:camelize) { false }
-
-          it 'specifies :original input formatter' do
-            expect(attribute.options[:input_format]).to eq :original
-          end
         end
       end
 
@@ -105,20 +89,6 @@ module GraphqlRails
         context 'when attribute is required' do
           it 'builds required field' do
             expect(field_args.last).to include(null: false)
-          end
-        end
-
-        context 'when attribute is set to camelize' do
-          it 'builds required field' do
-            expect(field_args.last).to include(camelize: true)
-          end
-        end
-
-        context 'when attribute is set not to camelize' do
-          let(:camelize) { false }
-
-          it 'builds required field' do
-            expect(field_args.last).to include(camelize: false)
           end
         end
 

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -19,7 +19,7 @@ module GraphqlRails
 
       describe '#options' do
         it 'sets options correctly' do
-          expect { attribute.options(new_option: true) }.to change(attribute, :options).to({ new_option: true })
+          expect { attribute.options(new_option: true) }.to change(attribute, :options).to(new_option: true)
         end
       end
 

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -5,14 +5,21 @@ require 'spec_helper'
 module GraphqlRails
   module Attributes
     RSpec.describe Attribute do
-      subject(:attribute) { described_class.new(name, type) }
+      subject(:attribute) { described_class.new(name, type, camelize: camelize) }
 
       let(:type) { 'String!' }
       let(:name) { 'full_name' }
+      let(:camelize) { true }
 
       describe '#property' do
         it 'sets property correctly' do
           expect { attribute.property(:new_property) }.to change(attribute, :property).to('new_property')
+        end
+      end
+
+      describe '#camelize' do
+        it 'sets camelize flag correctly' do
+          expect { attribute.camelize(false) }.to change(attribute, :camelize).to(false)
         end
       end
 
@@ -24,7 +31,7 @@ module GraphqlRails
         end
       end
 
-      describe '#optiona' do
+      describe '#optional' do
         it 'marks attribute as not required' do
           expect { attribute.optional }.to change(attribute, :required?).to(false)
         end
@@ -39,6 +46,22 @@ module GraphqlRails
       describe '#type' do
         it 'sets type correctly' do
           expect { attribute.type(:int!) }.to change(attribute, :type).to(:int!)
+        end
+      end
+
+      describe '#options' do
+        context 'when camelize is true' do
+          it 'does not specify input format' do
+            expect(attribute.options[:input_format]).to be_nil
+          end
+        end
+
+        context 'when camelize is false' do
+          let(:camelize) { false }
+  
+          it 'specifies :original input formatter' do
+            expect(attribute.options[:input_format]).to eq :original
+          end
         end
       end
 
@@ -82,6 +105,20 @@ module GraphqlRails
         context 'when attribute is required' do
           it 'builds required field' do
             expect(field_args.last).to include(null: false)
+          end
+        end
+
+        context 'when attribute is set to camelize' do
+          it 'builds required field' do
+            expect(field_args.last).to include(camelize: true)
+          end
+        end
+
+        context 'when attribute is set not to camelize' do
+          let(:camelize) { false }
+
+          it 'builds required field' do
+            expect(field_args.last).to include(camelize: false)
           end
         end
 


### PR DESCRIPTION
This allows passing `options` flag to attribute defined on the model level. See linked issue #148 