### PR TITLE
Fix camelize option forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 * Added: `options` argument to model level attribute. Allows disabling automatic camelCase
+* Fixed: camelize option not being forwarded to GraphQL gem.
 
 ## [1.0.0](2020-02-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 * Added: `options` argument to model level attribute. Allows disabling automatic camelCase
-* Fixed: camelize option not being forwarded to GraphQL gem.
 
 ## [1.0.0](2020-02-07)
 

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -61,7 +61,7 @@ module GraphqlRails
           {
             method: property.to_sym,
             null: optional?,
-            camelize: !camelize?
+            camelize: camelize?
           }
         ]
       end
@@ -84,7 +84,7 @@ module GraphqlRails
       private
 
       def camelize?
-        options[:input_format] == :original || options[:attribute_name_format] == :original
+        options[:input_format] != :original && options[:attribute_name_format] != :original
       end
     end
   end

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -60,7 +60,8 @@ module GraphqlRails
           *description,
           {
             method: property.to_sym,
-            null: optional?
+            null: optional?,
+            camelize: !camelize?
           }
         ]
       end
@@ -79,6 +80,12 @@ module GraphqlRails
       protected
 
       attr_reader :initial_type, :initial_name
+
+      private
+
+      def camelize?
+        options[:input_format] == :original || options[:attribute_name_format] == :original
+      end
     end
   end
 end

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -92,6 +92,23 @@ module GraphqlRails
           end
         end
 
+        context 'when atribute name format options are passed' do
+          let(:options) { { attribute_name_format: :original } }
+
+          it 'forwards disables camelize' do
+            expect(field_args.last).to include(camelize: false)
+          end
+        end
+
+        context 'when atribute name format options are not passed' do
+          it 'ignores keeps camelize active' do
+            expect(field_args.last).to include(camelize: true)
+          end
+        end
+
+        context 'when camelize options are not passed' do
+        end
+
         context 'when attribute is optional' do
           let(:type) { 'String' }
 

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -106,9 +106,6 @@ module GraphqlRails
           end
         end
 
-        context 'when camelize options are not passed' do
-        end
-
         context 'when attribute is optional' do
           let(:type) { 'String' }
 


### PR DESCRIPTION
Fixes the case where camelize is not used on attribute name, but on GraphQL gem internals it was still expected to be camelized. #149 