### PR TITLE
Fix: allow required field in attribute type definition

### DIFF
--- a/lib/graphql_rails/model/configuration.rb
+++ b/lib/graphql_rails/model/configuration.rb
@@ -32,7 +32,10 @@ module GraphqlRails
 
         attributes[key].tap do |attribute|
           attribute_options.each do |method_name, args|
-            attribute.public_send(method_name, args)
+            send_args = [method_name]
+            send_args << args if attribute.method(method_name).parameters.present?
+
+            attribute.public_send(*send_args)
           end
 
           yield(attribute) if block_given?

--- a/spec/lib/graphql_rails/model/configuration_spec.rb
+++ b/spec/lib/graphql_rails/model/configuration_spec.rb
@@ -102,6 +102,29 @@ module GraphqlRails
           expect(field.arguments.keys).to match_array(%w[after before first last name])
         end
       end
+
+      context 'when attribute definition contains required flag' do
+        let(:model) do
+          Class.new do
+            include GraphqlRails::Model
+
+            graphql do |c|
+              c.description 'Used for test purposes'
+              c.attribute :required_field, required: true
+            end
+
+            def self.name
+              'DummyModel'
+            end
+          end
+        end
+
+        let(:field) { model.graphql.graphql_type.fields['requiredField'] }
+
+        it 'is registered as required' do
+          expect(field.type).to be_a_kind_of(GraphQL::NonNullType)
+        end
+      end
     end
 
     describe '#graphql_type' do


### PR DESCRIPTION
When an attribute is being defined as `required` through parameter passing, rather than method chaining, an error gets triggered that prevents schema generation. This is an attempt to fix that issue.