### PR TITLE
Fix graphql errors formatting

### DIFF
--- a/lib/graphql_rails/controller/request.rb
+++ b/lib/graphql_rails/controller/request.rb
@@ -16,7 +16,7 @@ module GraphqlRails
       end
 
       def errors=(new_errors)
-        @errors = FormatErrors.call(new_errors)
+        @errors = FormatErrors.call(not_formatted_errors: new_errors)
 
         @errors.each { |error| context.add_error(error) }
       end

--- a/lib/graphql_rails/controller/request/format_errors.rb
+++ b/lib/graphql_rails/controller/request/format_errors.rb
@@ -12,7 +12,7 @@ module GraphqlRails
       class FormatErrors
         include Service
 
-        def initialize(not_formatted_errors)
+        def initialize(not_formatted_errors:)
           @not_formatted_errors = not_formatted_errors
         end
 

--- a/spec/lib/graphql_rails/controller/request/format_errors_spec.rb
+++ b/spec/lib/graphql_rails/controller/request/format_errors_spec.rb
@@ -5,7 +5,7 @@ require 'active_model'
 
 module GraphqlRails
   RSpec.describe Controller::Request::FormatErrors do
-    subject(:format_errors) { described_class.new(errors) }
+    subject(:format_errors) { described_class.new(not_formatted_errors: errors) }
 
     let(:errors) { ['boom!'] }
 


### PR DESCRIPTION
After updating graphql rails to support Ruby 2.7 and refactoring code base graphql service was changed and it enforced `FormatErrors` service arguments (`ActiveModel::Error`) to be transformed to hash.
This PR fixes it. 