### PR TITLE
Fix type name caching issue

### DIFF
--- a/lib/graphql_rails/model/configurable.rb
+++ b/lib/graphql_rails/model/configurable.rb
@@ -15,7 +15,7 @@ module GraphqlRails
       end
 
       def type_name
-        "#{name.camelize}Type#{SecureRandom.hex}"
+        @type_name ||= "#{name.camelize}Type#{SecureRandom.hex}"
       end
 
       def description(new_description = nil)


### PR DESCRIPTION
Circular dependency still occurs if type name is not cached. Type name should be cached value.