### PR TITLE
Bump graphql version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     graphql_rails (1.1.0)
       activesupport (>= 4)
-      graphql (~> 1.11, >= 1.11.6)
+      graphql (~> 1.12, >= 1.12.4)
 
 GEM
   remote: https://rubygems.org/
@@ -78,7 +78,7 @@ GEM
     erubi (1.9.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.11.6)
+    graphql (1.12.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.1)

--- a/graphql_rails.gemspec
+++ b/graphql_rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'graphql', '~> 1.11', '>= 1.11.6'
+  spec.add_dependency 'graphql', '~> 1.12', '>= 1.12.4'
   spec.add_dependency 'activesupport', '>= 4'
 
   spec.add_development_dependency 'bundler', '~> 2'

--- a/lib/graphql_rails/router/schema_builder.rb
+++ b/lib/graphql_rails/router/schema_builder.rb
@@ -26,6 +26,12 @@ module GraphqlRails
 
           query(query_type) if query_type
           mutation(mutation_type) if mutation_type
+
+          def self.type_from_ast(*args)
+            type = super
+
+            type.respond_to?(:to_graphql) ? type.to_graphql : type
+          end
         end
       end
 


### PR DESCRIPTION
Bumping `graphql` version. Patch in schema is required due to an existing bug in `graphql` gem (https://github.com/rmosolgo/graphql-ruby/pull/2814). 