### PR TITLE
Remove deprecated graphql types

### DIFF
--- a/lib/graphql_rails/attributes/attributable.rb
+++ b/lib/graphql_rails/attributes/attributable.rb
@@ -47,7 +47,7 @@ module GraphqlRails
       end
 
       def scalar_type?
-        type_parser.raw_graphql_type? || type_parser.unwrapped_scalar_type.class == GraphQL::ScalarType
+        type_parser.raw_graphql_type? || type_parser.core_scalar_type?
       end
 
       private

--- a/lib/graphql_rails/attributes/attribute_name_parser.rb
+++ b/lib/graphql_rails/attributes/attribute_name_parser.rb
@@ -27,11 +27,11 @@ module GraphqlRails
         @graphql_type ||= \
           case name
           when 'id', /_id\Z/
-            GraphQL::ID_TYPE
+            GraphQL::Types::ID
           when /\?\Z/
-            GraphQL::BOOLEAN_TYPE
+            GraphQL::Types::Boolean
           else
-            GraphQL::STRING_TYPE
+            GraphQL::Types::String
           end
       end
 

--- a/lib/graphql_rails/attributes/type_parseable.rb
+++ b/lib/graphql_rails/attributes/type_parseable.rb
@@ -11,23 +11,23 @@ module GraphqlRails
       class UnknownTypeError < ArgumentError; end
 
       TYPE_MAPPING = {
-        'id' => GraphQL::ID_TYPE,
+        'id' => GraphQL::Types::ID,
 
-        'int' => GraphQL::INT_TYPE,
-        'integer' => GraphQL::INT_TYPE,
+        'int' => GraphQL::Types::Int,
+        'integer' => GraphQL::Types::Int,
 
-        'string' => GraphQL::STRING_TYPE,
-        'str' => GraphQL::STRING_TYPE,
-        'text' => GraphQL::STRING_TYPE,
-        'time' => GraphQL::STRING_TYPE,
-        'date' => GraphQL::STRING_TYPE,
+        'string' => GraphQL::Types::String,
+        'str' => GraphQL::Types::String,
+        'text' => GraphQL::Types::String,
+        'time' => GraphQL::Types::String,
+        'date' => GraphQL::Types::String,
 
-        'bool' => GraphQL::BOOLEAN_TYPE,
-        'boolean' => GraphQL::BOOLEAN_TYPE,
+        'bool' => GraphQL::Types::Boolean,
+        'boolean' => GraphQL::Types::Boolean,
 
-        'float' => GraphQL::FLOAT_TYPE,
-        'double' => GraphQL::FLOAT_TYPE,
-        'decimal' => GraphQL::FLOAT_TYPE
+        'float' => GraphQL::Types::Float,
+        'double' => GraphQL::Types::Float,
+        'decimal' => GraphQL::Types::Float
       }.freeze
 
       WRAPPER_TYPES = [
@@ -55,6 +55,10 @@ module GraphqlRails
         defined?(GraphQL::Schema::Member) &&
           unparsed_type.is_a?(Class) &&
           unparsed_type < GraphQL::Schema::Member
+      end
+
+      def core_scalar_type?
+        unwrapped_scalar_type.in?(TYPE_MAPPING.values)
       end
 
       def graphql_model

--- a/lib/graphql_rails/router/schema_builder.rb
+++ b/lib/graphql_rails/router/schema_builder.rb
@@ -30,12 +30,6 @@ module GraphqlRails
 
           query(query_type) if query_type
           mutation(mutation_type) if mutation_type
-
-          def self.type_from_ast(*args)
-            type = super
-
-            type.respond_to?(:to_graphql) ? type.to_graphql : type
-          end
         end
       end
 

--- a/spec/lib/graphql_rails/attributes/attribute_name_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_name_parser_spec.rb
@@ -63,7 +63,7 @@ module GraphqlRails
           let(:name) { :admin? }
 
           it 'returns boolean type' do
-            expect(graphql_type).to eq GraphQL::BOOLEAN_TYPE
+            expect(graphql_type).to eq GraphQL::Types::Boolean
           end
         end
 
@@ -71,13 +71,13 @@ module GraphqlRails
           let(:name) { :id }
 
           it 'returns id type' do
-            expect(graphql_type).to eq GraphQL::ID_TYPE
+            expect(graphql_type).to eq GraphQL::Types::ID
           end
         end
 
         context 'when name does not end with special suffix' do
           it 'returns String type' do
-            expect(graphql_type).to eq GraphQL::STRING_TYPE
+            expect(graphql_type).to eq GraphQL::Types::String
           end
         end
       end

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -59,7 +59,7 @@ module GraphqlRails
             let(:name) { :admin? }
 
             it 'returns boolean type' do
-              expect(field_args[1]).to eq GraphQL::BOOLEAN_TYPE
+              expect(field_args[1]).to eq GraphQL::Types::Boolean
             end
           end
 
@@ -67,7 +67,7 @@ module GraphqlRails
             let(:name) { :id }
 
             it 'returns id type' do
-              expect(field_args[1]).to eq GraphQL::ID_TYPE
+              expect(field_args[1]).to eq GraphQL::Types::ID
             end
           end
         end
@@ -79,7 +79,7 @@ module GraphqlRails
             let(:type) { '[Int]!' }
 
             it 'builds optional list type field' do
-              expect(field_args[1]).to eq([GraphQL::INT_TYPE, null: true])
+              expect(field_args[1]).to eq([GraphQL::Types::Int, null: true])
             end
           end
 
@@ -87,13 +87,13 @@ module GraphqlRails
             let(:type) { '[Int!]' }
 
             it 'builds required inner array type' do
-              expect(field_args[1]).to eq([GraphQL::INT_TYPE])
+              expect(field_args[1]).to eq([GraphQL::Types::Int])
             end
           end
 
           context 'when array and its inner type is required' do
             it 'builds required inner array type' do
-              expect(field_args[1]).to eq([GraphQL::INT_TYPE])
+              expect(field_args[1]).to eq([GraphQL::Types::Int])
             end
           end
 
@@ -101,7 +101,7 @@ module GraphqlRails
             let(:type) { '[Int]' }
 
             it 'builds optional list type field' do
-              expect(field_args[1]).to eq([GraphQL::INT_TYPE, null: true])
+              expect(field_args[1]).to eq([GraphQL::Types::Int, null: true])
             end
           end
         end

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -28,7 +28,7 @@ module GraphqlRails
 
         context 'when type is basic scalar type' do
           it 'returns graphql scalar type' do
-            expect(input_argument_type).to eq(GraphQL::STRING_TYPE)
+            expect(input_argument_type).to eq(GraphQL::Types::String)
           end
 
           it 'returns required type' do

--- a/spec/lib/graphql_rails/attributes/type_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/type_parser_spec.rb
@@ -22,7 +22,7 @@ module GraphqlRails
         end
 
         context 'when graphql type is provided' do
-          let(:type) { GraphQL::INT_TYPE }
+          let(:type) { GraphQL::Types::Int }
 
           it { is_expected.to be_nil }
         end
@@ -56,7 +56,7 @@ module GraphqlRails
               let(:type) { '[String]!' }
 
               it 'returns correct structore' do
-                expect(type_arg).to eq([GraphQL::STRING_TYPE, { null: true }])
+                expect(type_arg).to eq([GraphQL::Types::String, { null: true }])
               end
             end
 
@@ -64,7 +64,7 @@ module GraphqlRails
               let(:type) { '[String]' }
 
               it 'returns correct structore' do
-                expect(type_arg).to eq([GraphQL::STRING_TYPE, { null: true }])
+                expect(type_arg).to eq([GraphQL::Types::String, { null: true }])
               end
             end
           end
@@ -104,25 +104,25 @@ module GraphqlRails
         context 'when attribute is integer' do
           let(:type) { 'Int' }
 
-          it { is_expected.to be GraphQL::INT_TYPE }
+          it { is_expected.to be GraphQL::Types::Int }
         end
 
         context 'when attribute is ID' do
           let(:type) { 'ID' }
 
-          it { is_expected.to be GraphQL::ID_TYPE }
+          it { is_expected.to be GraphQL::Types::ID }
         end
 
         context 'when attribute is boolean' do
           let(:type) { 'bool' }
 
-          it { is_expected.to be GraphQL::BOOLEAN_TYPE }
+          it { is_expected.to be GraphQL::Types::Boolean }
         end
 
         context 'when attribute is float type' do
           let(:type) { 'float' }
 
-          it { is_expected.to be GraphQL::FLOAT_TYPE }
+          it { is_expected.to be GraphQL::Types::Float }
         end
 
         context 'when attribute is not supported' do

--- a/spec/lib/graphql_rails/controller/action_configuration_spec.rb
+++ b/spec/lib/graphql_rails/controller/action_configuration_spec.rb
@@ -149,9 +149,10 @@ module GraphqlRails
             config.model('String')
           end
 
-          it 'sets required model return type' do
+          it 'sets required model return type', :aggregate_failures do
             config.returns_single
-            expect(config.return_type).to eq(!GraphQL::STRING_TYPE)
+            expect(config.return_type).to be_instance_of(GraphQL::Schema::NonNull)
+            expect(config.return_type.of_type).to eq(GraphQL::Types::String)
           end
         end
 
@@ -162,7 +163,7 @@ module GraphqlRails
 
           it 'sets nullable model return type' do
             config.returns_single(required: false)
-            expect(config.return_type).to eq(GraphQL::STRING_TYPE)
+            expect(config.return_type).to eq(GraphQL::Types::String)
           end
         end
       end
@@ -180,9 +181,12 @@ module GraphqlRails
             config.model('String')
           end
 
-          it 'sets required list model return type' do
+          it 'sets required list model return type', :aggregate_failures do
             config.returns_list
-            expect(config.return_type).to eq(!(!GraphQL::STRING_TYPE).to_list_type)
+            expect(config.return_type).to be_instance_of(GraphQL::Schema::NonNull)
+            expect(config.return_type.of_type).to be_instance_of(GraphQL::Schema::List)
+            expect(config.return_type.of_type.of_type).to be_instance_of(GraphQL::Schema::NonNull)
+            expect(config.return_type.of_type.of_type.of_type).to eq(GraphQL::Types::String)
           end
         end
 
@@ -191,9 +195,11 @@ module GraphqlRails
             config.model('String')
           end
 
-          it 'sets nullable model return type' do
+          it 'sets nullable model return type', :aggregate_failures do
             config.returns_list(required_inner: false)
-            expect(config.return_type).to eq(!GraphQL::STRING_TYPE.to_list_type)
+            expect(config.return_type).to be_instance_of(GraphQL::Schema::NonNull)
+            expect(config.return_type.of_type).to be_instance_of(GraphQL::Schema::List)
+            expect(config.return_type.of_type.of_type).to eq(GraphQL::Types::String)
           end
         end
 
@@ -202,9 +208,11 @@ module GraphqlRails
             config.model('String')
           end
 
-          it 'sets nullable model return type' do
+          it 'sets nullable model return type', :aggregate_failures do
             config.returns_list(required_list: false)
-            expect(config.return_type).to eq((!GraphQL::STRING_TYPE).to_list_type)
+            expect(config.return_type).to be_instance_of(GraphQL::Schema::List)
+            expect(config.return_type.of_type).to be_instance_of(GraphQL::Schema::NonNull)
+            expect(config.return_type.of_type.of_type).to eq(GraphQL::Types::String)
           end
         end
       end

--- a/spec/lib/graphql_rails/controller/action_spec.rb
+++ b/spec/lib/graphql_rails/controller/action_spec.rb
@@ -10,7 +10,7 @@ module GraphqlRails
     RSpec.describe Action do
       class CustomDummyUsersController < GraphqlRails::Controller; end
       class DummyUsersController < GraphqlRails::Controller
-        action(:show).returns(GraphQL::STRING_TYPE.to_non_null_type)
+        action(:show).returns(GraphQL::Types::String.to_non_null_type)
         action(:paginated_index).paginated
       end
 
@@ -44,7 +44,7 @@ module GraphqlRails
           let(:action_name) { 'show' }
 
           it 'uses specified type' do
-            expect(return_type).to eq(GraphQL::STRING_TYPE.to_non_null_type)
+            expect(return_type).to eq(GraphQL::Types::String.to_non_null_type)
           end
         end
       end

--- a/spec/lib/graphql_rails/model/configuration_spec.rb
+++ b/spec/lib/graphql_rails/model/configuration_spec.rb
@@ -122,7 +122,7 @@ module GraphqlRails
         let(:field) { model.graphql.graphql_type.fields['requiredField'] }
 
         it 'is registered as required' do
-          expect(field.type).to be_a_kind_of(GraphQL::NonNullType)
+          expect(field.type).to be_a_kind_of(GraphQL::Schema::NonNull)
         end
       end
     end


### PR DESCRIPTION
This fixes incorrect type resolutions leading to type mismatch errors.

You should no longer use `GraphQL::STRING_TYPE` in your application, use `GraphQL::Types::String` instead. This is part of `graphql` 11.6->12.4 upgrade which was not done correctly in the initial release of version 1.2.0