### PR TITLE
Refs #185: Fix required list type implementation

### DIFF
--- a/lib/graphql_rails/attributes/attributable.rb
+++ b/lib/graphql_rails/attributes/attributable.rb
@@ -21,11 +21,9 @@ module GraphqlRails
       end
 
       def required?
-        if @required.nil?
-          attribute_name_parser.required? || !initial_type.to_s[/!$/].nil?
-        else
-          @required
-        end
+        return @required unless @required.nil?
+
+        attribute_name_parser.required? || !initial_type.to_s[/!$/].nil? || initial_type.is_a?(GraphQL::Schema::NonNull)
       end
 
       def required

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -72,6 +72,14 @@ module GraphqlRails
           end
         end
 
+        context 'when attribute is GraphQL::Schema::NonNull instance' do
+          let(:type) { GraphQL::Schema::NonNull.new(GraphQL::Types::String) }
+
+          it 'builds required type' do
+            expect(field_args[1]).to eq(GraphQL::Types::String)
+          end
+        end
+
         context 'when attribute is array' do
           let(:type) { '[Int!]!' }
 
@@ -109,6 +117,14 @@ module GraphqlRails
 
       describe '#field_options' do
         subject(:field_options) { attribute.field_options }
+
+        context 'when attribute is GraphQL::Schema::NonNull instance' do
+          let(:type) { GraphQL::Schema::NonNull.new(GraphQL::Types::String) }
+
+          it 'builds required field' do
+            expect(field_options).to include(null: false)
+          end
+        end
 
         context 'when type is not set' do
           let(:type) { nil }


### PR DESCRIPTION
Fixes attribute type parser.  Instances of `GraphQL::Schema::NonNull` are marked as required, making the schema generation work as expected.