### PR TITLE
Use items instead of nodes as they're pre-paginated

### DIFF
--- a/lib/graphql_rails/model/build_connection_type.rb
+++ b/lib/graphql_rails/model/build_connection_type.rb
@@ -33,7 +33,7 @@ module GraphqlRails
           field :total, Integer, null: false
 
           def total
-            CountItems.call(self)
+            CountItems.call(object)
           end
         end
       end

--- a/lib/graphql_rails/model/build_connection_type/count_items.rb
+++ b/lib/graphql_rails/model/build_connection_type/count_items.rb
@@ -27,7 +27,7 @@ module GraphqlRails
         attr_reader :graphql_object
 
         def list
-          graphql_object.nodes
+          graphql_object.items
         end
 
         def active_record?

--- a/spec/lib/graphql_rails/model/build_connection_type/count_items_spec.rb
+++ b/spec/lib/graphql_rails/model/build_connection_type/count_items_spec.rb
@@ -7,7 +7,7 @@ class GraphqlRails::Model::BuildConnectionType
   RSpec.describe CountItems do
     subject(:count_items) { described_class.new(graphql_object) }
 
-    let(:graphql_object) { double('GraphqlObject', nodes: items) } # rubocop:disable RSpec/VerifiedDoubles
+    let(:graphql_object) { double('GraphqlObject', items: items) } # rubocop:disable RSpec/VerifiedDoubles
 
     describe '.call' do
       subject(:call) { described_class.call(graphql_object) }


### PR DESCRIPTION
Using `nodes` is not correct there, as it takes pagination into account. So you'll always have `total` = maximum entries per page, which will always end up with a single page. Instead, use `items` which is implemented by ActiveRecordConnectionWraper.