### PR TITLE
Fix/188 dynamic type definition take two

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.2)

--- a/lib/graphql_rails/model.rb
+++ b/lib/graphql_rails/model.rb
@@ -28,7 +28,7 @@ module GraphqlRails
 
       def graphql
         @graphql ||= Model::Configuration.new(self)
-        yield(@graphql) if block_given?
+        @graphql.tap { |it| yield(it) }.with_ensured_fields! if block_given?
         @graphql
       end
     end

--- a/lib/graphql_rails/model/configuration.rb
+++ b/lib/graphql_rails/model/configuration.rb
@@ -69,7 +69,7 @@ module GraphqlRails
       end
 
       def with_ensured_fields!
-        return self unless @graphql_type.present?
+        return self if @graphql_type.blank?
 
         reset_graphql_type if attributes.any? && graphql_type.fields.length != attributes.length
 

--- a/lib/graphql_rails/model/configuration.rb
+++ b/lib/graphql_rails/model/configuration.rb
@@ -68,12 +68,30 @@ module GraphqlRails
         @connection_type ||= BuildConnectionType.call(graphql_type)
       end
 
+      def with_ensured_fields!
+        return self unless @graphql_type.present?
+
+        reset_graphql_type if attributes.any? && graphql_type.fields.length != attributes.length
+
+        self
+      end
+
       private
 
       attr_reader :model_class
 
       def default_name
         @default_name ||= model_class.name.split('::').last
+      end
+
+      def reset_graphql_type
+        @graphql_type = FindOrBuildGraphqlType.call(
+          name: name,
+          description: description,
+          attributes: attributes,
+          type_name: type_name,
+          force_define_attributes: true
+        )
       end
     end
   end

--- a/lib/graphql_rails/model/find_or_build_graphql_type.rb
+++ b/lib/graphql_rails/model/find_or_build_graphql_type.rb
@@ -10,20 +10,21 @@ module GraphqlRails
 
       include ::GraphqlRails::Service
 
-      def initialize(name:, description:, attributes:, type_name:)
+      def initialize(name:, description:, attributes:, type_name:, force_define_attributes: false)
         @name = name
         @description = description
         @attributes = attributes
         @type_name = type_name
+        @force_define_attributes = force_define_attributes
       end
 
       def call
-        klass.tap { add_fields_to_graphql_type if new_class? }
+        klass.tap { add_fields_to_graphql_type if new_class? || force_define_attributes }
       end
 
       private
 
-      attr_reader :name, :description, :attributes, :type_name
+      attr_reader :name, :description, :attributes, :type_name, :force_define_attributes
 
       delegate :klass, :new_class?, to: :type_class_finder
 

--- a/spec/lib/graphql_rails/model/configuration_spec.rb
+++ b/spec/lib/graphql_rails/model/configuration_spec.rb
@@ -181,6 +181,41 @@ module GraphqlRails
       end
     end
 
+    describe '#with_ensured_fields!' do
+      before { config.graphql_type } # sets instance variable
+
+      context 'when graphql_type is already defined' do
+        context 'when fields defined on type equals to defined fields on config' do
+          it 'does not invoke forced graphql type reset' do
+            allow(config).to receive(:reset_graphql_type).and_call_original
+            config.with_ensured_fields!
+            expect(config).not_to have_received(:reset_graphql_type)
+          end
+        end
+
+        context 'when fields defined on type is different to defined fields on config' do
+          it 'does invoke forced graphql type reset' do
+            config.attribute(:another_id, type: 'ID')
+            allow(config).to receive(:reset_graphql_type).and_call_original
+            config.with_ensured_fields!
+            expect(config).to have_received(:reset_graphql_type)
+          end
+        end
+      end
+
+      context 'when graphql_type is not yet defined' do
+        before do
+          config.instance_variable_set(:@graphql_type, nil)
+        end
+
+        it 'does not invoke forced graphql type reset' do
+          allow(config).to receive(:reset_graphql_type).and_call_original
+          config.with_ensured_fields!
+          expect(config).not_to have_received(:reset_graphql_type)
+        end
+      end
+    end
+
     describe '#input' do
       subject(:input) { config.input(:new_input) }
 

--- a/spec/lib/graphql_rails/model/find_or_build_graphql_type_spec.rb
+++ b/spec/lib/graphql_rails/model/find_or_build_graphql_type_spec.rb
@@ -11,12 +11,14 @@ module GraphqlRails
             name: name,
             description: description,
             attributes: name.constantize.graphql.attributes,
-            type_name: name.constantize.graphql.type_name
+            type_name: name.constantize.graphql.type_name,
+            force_define_attributes: force_define_attributes
           )
         end
 
         let(:name) { 'DummyType' }
         let(:description) { 'This is my type!' }
+        let(:force_define_attributes) { false }
 
         before do
           stub_const(name, dummy_model_class)
@@ -77,6 +79,40 @@ module GraphqlRails
 
           it 'builds type with correct arguments' do
             expect(call.fields['name'].arguments.keys).to match_array(%w[length])
+          end
+        end
+
+        context 'when force redefine is required' do
+          let(:dummy_model_class) do
+            graphql_name = name
+            graphql_description = description
+
+            Class.new do
+              include Model
+
+              graphql do |c|
+                c.name graphql_name
+                c.description graphql_description
+
+                c.attribute :name
+              end
+            end
+          end
+
+          before do
+            described_class.call(
+              name: name,
+              description: description,
+              attributes: {},
+              type_name: name.constantize.graphql.type_name,
+              force_define_attributes: false
+            ) # Sets the type with zero fields
+          end
+
+          let(:force_define_attributes) { true }
+
+          it 'builds type with correct fields count' do
+            expect(call.fields.count).to eq(1)
           end
         end
 

--- a/spec/lib/graphql_rails/model/find_or_build_graphql_type_spec.rb
+++ b/spec/lib/graphql_rails/model/find_or_build_graphql_type_spec.rb
@@ -83,6 +83,7 @@ module GraphqlRails
         end
 
         context 'when force redefine is required' do
+          let(:force_define_attributes) { true }
           let(:dummy_model_class) do
             graphql_name = name
             graphql_description = description
@@ -108,8 +109,6 @@ module GraphqlRails
               force_define_attributes: false
             ) # Sets the type with zero fields
           end
-
-          let(:force_define_attributes) { true }
 
           it 'builds type with correct fields count' do
             expect(call.fields.count).to eq(1)

--- a/spec/lib/graphql_rails/model_spec.rb
+++ b/spec/lib/graphql_rails/model_spec.rb
@@ -68,6 +68,40 @@ module GraphqlRails
           expect(child_fields).to match_array(%w[childInputAttribute parentInputAttribute])
         end
       end
+
+      context 'when defining configuration' do
+        let(:plain_model) do
+          Class.new do
+            include GraphqlRails::Model
+
+            def self.name
+              'DummyModel'
+            end
+          end
+        end
+
+        let(:graphql_stub) do
+          instance_double(GraphqlRails::Model::Configuration, 'with_ensured_fields!' => true, attribute: nil)
+        end
+
+        context 'when configuration block is given' do
+          it 'ensures correct fields' do
+            plain_model.instance_variable_set(:@graphql, graphql_stub)
+            plain_model.graphql do |g|
+              g.attribute :id
+            end
+            expect(graphql_stub).to have_received(:with_ensured_fields!)
+          end
+        end
+
+        context 'when configuration block is not given' do
+          it 'does not ensure fields' do
+            plain_model.instance_variable_set(:@graphql, graphql_stub)
+            plain_model.graphql
+            expect(graphql_stub).not_to have_received(:with_ensured_fields!)
+          end
+        end
+      end
     end
 
     describe '#with_graphql_context' do


### PR DESCRIPTION
Fixes #188 in a way that if `graphql` is called with a block passed, it compares attributes with already defined ones, and in case there is a difference, it redefines the type. This also means, that if you use `graphql {}` this will essentially clear previously defined attributes.

Considering to add `warn` or `raise` in case `graphql` block is executed without any arguments defined, as I can't really see the use case of that, but it will come with a separate PR.