### PR TITLE
Repo automation update for ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,10 @@
 name: Ruby
-on: push
+on: [push, pull_request]
 jobs:
   specs:
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7'] # TODO: 3.0 support
+        ruby-version: ['2.6', '2.7', '3.0']
 
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This PR:
 - [x] Enables testing against ruby 3.0
 - [x] Fixes issue of automation hanging on fork originated pull requests