### PR TITLE
Do not inherit parent graphql_type when using inheritance

### DIFF
--- a/lib/graphql_rails/model/configurable.rb
+++ b/lib/graphql_rails/model/configurable.rb
@@ -10,7 +10,7 @@ module GraphqlRails
         @name = nil
         @type_name = nil
         @description = nil
-        @attributes = other.instance_variable_get(:@attributes)&.transform_values(&:dup)
+        @attributes = other.attributes.transform_values(&:dup)
       end
 
       def attributes

--- a/lib/graphql_rails/model/configurable.rb
+++ b/lib/graphql_rails/model/configurable.rb
@@ -5,6 +5,14 @@ module GraphqlRails
     # contains methods which are shared between various configurations
     # expects `default_name` to be defined
     module Configurable
+      def initialize_copy(other)
+        super
+        @name = nil
+        @type_name = nil
+        @description = nil
+        @attributes = other.instance_variable_get(:@attributes)&.transform_values(&:dup)
+      end
+
       def attributes
         @attributes ||= {}
       end

--- a/lib/graphql_rails/model/configuration.rb
+++ b/lib/graphql_rails/model/configuration.rb
@@ -22,7 +22,6 @@ module GraphqlRails
         @connection_type = nil
         @graphql_type = nil
         @input = other.instance_variable_get(:@input)&.transform_values(&:dup)
-        @attributes = other.instance_variable_get(:@attributes)&.transform_values(&:dup)
       end
 
       def attribute(attribute_name, **attribute_options)

--- a/lib/graphql_rails/model/input.rb
+++ b/lib/graphql_rails/model/input.rb
@@ -14,11 +14,6 @@ module GraphqlRails
         @input_name_suffix = input_name_suffix
       end
 
-      def initialize_copy(other)
-        super
-        @attributes = other.instance_variable_get(:@attributes)&.transform_values(&:dup)
-      end
-
       def graphql_input_type
         @graphql_input_type ||= BuildGraphqlInputType.call(
           name: name, description: description, attributes: attributes

--- a/spec/lib/graphql_rails/model_spec.rb
+++ b/spec/lib/graphql_rails/model_spec.rb
@@ -45,6 +45,7 @@ module GraphqlRails
         end
 
         before do
+          plain_model.graphql.graphql_type # force to set some configuration on parent class
           model
         end
 
@@ -56,6 +57,10 @@ module GraphqlRails
         it 'inherits parent class graphql attributes' do
           child_fields = model.graphql.graphql_type.fields.keys
           expect(child_fields).to match_array(%w[isPlain isChild])
+        end
+
+        it 'does not inherit parent class graphql_type' do
+          expect(model.graphql.graphql_type).not_to eq(plain_model.graphql.graphql_type)
         end
 
         it 'does not modify parent class input attributes' do


### PR DESCRIPTION
When using inheritance, parent and child classes same `graphql_type` which is not correct. This PR fixes that issue