### PR TITLE
Bump version V1.2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql_rails (1.2.5)
+    graphql_rails (1.2.6)
       activesupport (>= 4)
       graphql (~> 1.12, >= 1.12.4)
 

--- a/lib/graphql_rails/version.rb
+++ b/lib/graphql_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GraphqlRails
-  VERSION = '1.2.5'
+  VERSION = '1.2.6'
 end


### PR DESCRIPTION
I managed to break V1.2.5 release. I released it too early to rubygems and then removed it. Then tried to release again, but rubygems does not allow to release same version twice. So I'm creating V1.2.6 release with same code as in `v1.2.5`