### PR TITLE
Allow dumping multiple schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added: support for generating multiple schema dumps with `rake graphql_rails:schema:dump`
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [1.2.4](2021-05-05)

--- a/docs/other_tools/schema_dump.md
+++ b/docs/other_tools/schema_dump.md
@@ -8,16 +8,34 @@ rake graphql_rails:schema:dump
 
 ## Dumping non default schema
 
-You can have multiple graphql schemas. Read more about this in [routes section](components/routes). In order to generate schema for one of groups, provide optional `name` argument:
+You can have multiple graphql schemas. Read more about this in [routes section](components/routes).
+
+### Dumping single schema
+
+In order to generate schema for one of groups, provide optional `name` argument:
 
 ```bash
 rake graphql_rails:schema:dump['your_group_name']
 ```
 
-or using env variable `SCHEMA_GROUP_NAME`:
+or using ENV variable `SCHEMA_GROUP_NAME`:
 
 ```bash
-SCHEMA_GROUP_NAME=your_group_name rake graphql_rails:schema:dump
+SCHEMA_GROUP_NAME="your_group_name" rake graphql_rails:schema:dump
+```
+
+### Dumping multiple schemas
+
+In order to generate multiple schemas at once, separate group names by comma:
+
+```bash
+rake graphql_rails:schema:dump['your_group_name, your_group_name2']
+```
+
+or using ENV variable `SCHEMA_GROUP_NAME`:
+
+```bash
+SCHEMA_GROUP_NAME="your_group_name, your_group_name2" rake graphql_rails:schema:dump
 ```
 
 ## Dumping schema in to non default path

--- a/docs/other_tools/schema_dump.md
+++ b/docs/other_tools/schema_dump.md
@@ -6,42 +6,24 @@ GraphqlRails includes rake task to allow creating schema snapshots easier:
 rake graphql_rails:schema:dump
 ```
 
-## Dumping non default schema
+## Dumping only selected schema groups
 
-You can have multiple graphql schemas. Read more about this in [routes section](components/routes).
-
-### Dumping single schema
-
-In order to generate schema for one of groups, provide optional `name` argument:
-
-```bash
-rake graphql_rails:schema:dump['your_group_name']
-```
-
-or using ENV variable `SCHEMA_GROUP_NAME`:
-
-```bash
-SCHEMA_GROUP_NAME="your_group_name" rake graphql_rails:schema:dump
-```
-
-### Dumping multiple schemas
-
-In order to generate multiple schemas at once, separate group names by comma:
+You can specify which schema groups you want to dump. In order to do so, provide groups list as rake task argument and separate group names by comma:
 
 ```bash
 rake graphql_rails:schema:dump['your_group_name, your_group_name2']
 ```
 
-or using ENV variable `SCHEMA_GROUP_NAME`:
+You can do this also by using ENV variable `SCHEMA_GROUP_NAME`:
 
 ```bash
 SCHEMA_GROUP_NAME="your_group_name, your_group_name2" rake graphql_rails:schema:dump
 ```
 
-## Dumping schema in to non default path
+## Dumping schema in to non default folder
 
-By default schema will be dumped to `spec/fixtures/graphql_schema.graphql` path. If you want different schema path, add `GRAPHQL_SCHEMA_DUMP_PATH` env variable, like this:
+By default schema will be dumped to `spec/fixtures` directory. If you want different schema path, add `GRAPHQL_SCHEMA_DUMP_DIR` env variable, like this:
 
 ```bash
-GRAPHQL_SCHEMA_DUMP_PATH='path/to/my/schema.graphql' rake graphql_rails:schema:dump
+GRAPHQL_SCHEMA_DUMP_DIR='path/to/graphql/dumps' rake graphql_rails:schema:dump
 ```

--- a/lib/graphql_rails/router/route.rb
+++ b/lib/graphql_rails/router/route.rb
@@ -6,7 +6,7 @@ module GraphqlRails
   class Router
     # Generic class for any type graphql action. Should not be used directly
     class Route
-      attr_reader :name, :module_name, :on, :relative_path, :routes
+      attr_reader :name, :module_name, :on, :relative_path, :groups
 
       def initialize(name, to: '', on:, groups: nil, **options)
         @name = name.to_s.camelize(:lower)

--- a/lib/graphql_rails/router/route.rb
+++ b/lib/graphql_rails/router/route.rb
@@ -6,7 +6,7 @@ module GraphqlRails
   class Router
     # Generic class for any type graphql action. Should not be used directly
     class Route
-      attr_reader :name, :module_name, :on, :relative_path
+      attr_reader :name, :module_name, :on, :relative_path, :routes
 
       def initialize(name, to: '', on:, groups: nil, **options)
         @name = name.to_s.camelize(:lower)
@@ -43,7 +43,7 @@ module GraphqlRails
 
       private
 
-      attr_reader :function, :groups
+      attr_reader :function
 
       def resolver
         @resolver ||= Controller::BuildControllerActionResolver.call(route: self)

--- a/lib/graphql_rails/tasks/dump_graphql_schema.rb
+++ b/lib/graphql_rails/tasks/dump_graphql_schema.rb
@@ -11,9 +11,10 @@ module GraphqlRails
       new(**args).call
     end
 
-    def initialize(group:, router:)
+    def initialize(group:, router:, dump_dir: nil)
       @group = group
       @router = router
+      @dump_dir = dump_dir
     end
 
     def call
@@ -29,20 +30,14 @@ module GraphqlRails
     end
 
     def schema_path
-      ENV['GRAPHQL_SCHEMA_DUMP_PATH'] || default_schema_path
-    end
-
-    def default_schema_path
-      schema_folder_path = "#{root_path}/spec/fixtures"
-
-      FileUtils.mkdir_p(schema_folder_path)
+      FileUtils.mkdir_p(dump_dir)
       file_name = group.present? ? "graphql_#{group}_schema.graphql" : 'graphql_schema.graphql'
 
-      "#{schema_folder_path}/#{file_name}"
+      "#{dump_dir}/#{file_name}"
     end
 
-    def root_path
-      Rails.root
+    def dump_dir
+      @dump_dir ||= Rails.root.join('spec/fixtures').to_s
     end
   end
 end

--- a/lib/graphql_rails/tasks/dump_graphql_schemas.rb
+++ b/lib/graphql_rails/tasks/dump_graphql_schemas.rb
@@ -13,7 +13,7 @@ module GraphqlRails
       new(**args).call
     end
 
-    def initialize(groups: [], dump_dir:)
+    def initialize(dump_dir:, groups: nil)
       @groups = groups.presence
       @dump_dir = dump_dir
     end

--- a/lib/graphql_rails/tasks/dump_graphql_schemas.rb
+++ b/lib/graphql_rails/tasks/dump_graphql_schemas.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'graphql_rails/tasks/dump_graphql_schema'
+
 module GraphqlRails
   # Generates graphql schema dump files
   class DumpGraphqlSchemas
@@ -7,29 +9,32 @@ module GraphqlRails
 
     class MissingGraphqlRouterError < GraphqlRails::Error; end
 
-    attr_reader :name
-
     def self.call(**args)
       new(**args).call
     end
 
-    def initialize(groups: [])
+    def initialize(groups: [], dump_dir:)
       @groups = groups.presence
+      @dump_dir = dump_dir
     end
 
     def call
       validate
       return dump_default_schema if groups.empty?
 
-      groups.each do |group|
-        DumpGraphqlSchema.call(group: group)
-      end
+      groups.each { |group| dump_graphql_schema(group) }
     end
 
     private
 
+    attr_reader :dump_dir
+
     def dump_default_schema
-      DumpGraphqlSchema.call(group: '')
+      dump_graphql_schema('')
+    end
+
+    def dump_graphql_schema(group)
+      DumpGraphqlSchema.call(group: group, router: router, dump_dir: dump_dir)
     end
 
     def validate

--- a/lib/graphql_rails/tasks/dump_graphql_schemas.rb
+++ b/lib/graphql_rails/tasks/dump_graphql_schemas.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module GraphqlRails
+  # Generates graphql schema dump files
+  class DumpGraphqlSchemas
+    require 'graphql_rails/errors/error'
+
+    class MissingGraphqlRouterError < GraphqlRails::Error; end
+
+    attr_reader :name
+
+    def self.call(**args)
+      new(**args).call
+    end
+
+    def initialize(groups: [])
+      @groups = groups.presence
+    end
+
+    def call
+      validate
+      return dump_default_schema if groups.empty?
+
+      groups.each do |group|
+        DumpGraphqlSchema.call(group: group)
+      end
+    end
+
+    private
+
+    def dump_default_schema
+      DumpGraphqlSchema.call(group: '')
+    end
+
+    def validate
+      return if router
+
+      error_message = \
+        'GraphqlRouter is missing. ' \
+        'Run `rails g graphql_rails:install` to build it'
+      raise MissingGraphqlRouterError, error_message
+    end
+
+    def router
+      @router ||= '::GraphqlRouter'.safe_constantize
+    end
+
+    def groups
+      @groups ||= router.routes.flat_map(&:groups).uniq
+    end
+  end
+end

--- a/lib/graphql_rails/tasks/schema.rake
+++ b/lib/graphql_rails/tasks/schema.rake
@@ -5,10 +5,16 @@ require 'graphql_rails/tasks/dump_graphql_schema'
 namespace :graphql_rails do
   namespace :schema do
     desc 'Dump GraphQL schema'
-    task(:dump, %i[name] => :environment) do |_, args|
-      default_name = ENV.fetch('SCHEMA_GROUP_NAME', '')
-      args.with_defaults(name: default_name)
-      GraphqlRails::DumpGraphqlSchema.call(name: args.name)
+    task(dump: :environment) do |_, args|
+      names_from_args = args.extras
+      names_from_env = ENV['SCHEMA_GROUP_NAME'].to_s.split(',').map(&:strip)
+
+      group_names = names_from_args + names_from_env
+      group_names = [''] if group_names.empty?
+
+      group_names.each do |group_name|
+        GraphqlRails::DumpGraphqlSchema.call(name: group_name)
+      end
     end
   end
 end

--- a/lib/graphql_rails/tasks/schema.rake
+++ b/lib/graphql_rails/tasks/schema.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'graphql_rails/tasks/dump_graphql_schema'
+require 'graphql_rails/tasks/dump_graphql_schemas'
 
 namespace :graphql_rails do
   namespace :schema do
@@ -9,8 +9,9 @@ namespace :graphql_rails do
       groups_from_args = args.extras
       groups_from_env = ENV['SCHEMA_GROUP_NAME'].to_s.split(',').map(&:strip)
       groups = groups_from_args + groups_from_env
+      dump_dir = ENV.fetch('GRAPHQL_SCHEMA_DUMP_DIR') { Rails.root.join('spec/fixtures').to_s }
 
-      GraphqlRails::DumpGraphqlSchemas.call(groups: groups)
+      GraphqlRails::DumpGraphqlSchemas.call(groups: groups, dump_dir: dump_dir)
     end
   end
 end

--- a/lib/graphql_rails/tasks/schema.rake
+++ b/lib/graphql_rails/tasks/schema.rake
@@ -6,15 +6,11 @@ namespace :graphql_rails do
   namespace :schema do
     desc 'Dump GraphQL schema'
     task(dump: :environment) do |_, args|
-      names_from_args = args.extras
-      names_from_env = ENV['SCHEMA_GROUP_NAME'].to_s.split(',').map(&:strip)
+      groups_from_args = args.extras
+      groups_from_env = ENV['SCHEMA_GROUP_NAME'].to_s.split(',').map(&:strip)
+      groups = groups_from_args + groups_from_env
 
-      group_names = names_from_args + names_from_env
-      group_names = [''] if group_names.empty?
-
-      group_names.each do |group_name|
-        GraphqlRails::DumpGraphqlSchema.call(name: group_name)
-      end
+      GraphqlRails::DumpGraphqlSchemas.call(groups: groups)
     end
   end
 end

--- a/spec/lib/graphql_rails/tasks/dump_graphql_schema_spec.rb
+++ b/spec/lib/graphql_rails/tasks/dump_graphql_schema_spec.rb
@@ -5,44 +5,68 @@ require 'graphql_rails/tasks/dump_graphql_schema'
 
 module GraphqlRails
   RSpec.describe DumpGraphqlSchema do
-    subject(:dump_graphql_schema) { described_class.new(name: schema_name) }
+    subject(:dump_graphql_schema) { described_class.new(group: group, router: graphql_router) }
 
-    let(:schema_name) { nil }
+    let(:group) { nil }
+    let(:default_schema_path) { 'app/spec/fixtures/graphql_schema.graphql' }
 
-    let(:fake_schema_path) { 'tmp/schema_path/schema.graphql' }
+    let(:graphql_router) do
+      GraphqlRails::Router.draw {}
+    end
 
     before do
       # rubocop:disable RSpec/SubjectStub
-      allow(dump_graphql_schema).to receive(:schema_path).and_return('tmp/schema_path/schema.graphql')
+      allow(dump_graphql_schema).to receive(:root_path).and_return('app')
       # rubocop:enable RSpec/SubjectStub
 
-      allow(File).to receive(:write).and_call_original
-      allow(File).to receive(:write).with(fake_schema_path, kind_of(String)).and_return(1)
+      allow(FileUtils).to receive(:mkdir_p).and_return(nil)
+      allow(File).to receive(:write).and_return(1)
     end
 
     describe '#call' do
       subject(:call) { dump_graphql_schema.call }
 
-      context 'when "GraphqlRouter" is defined' do
-        let(:graphql_router) do
-          GraphqlRails::Router.draw {}
-        end
-
-        before do
-          stub_const('GraphqlRouter', graphql_router)
-        end
-
-        it 'writes router definition to file' do
+      context 'when group is blank' do
+        it 'writes router definition to default schema file' do
           call
-          expect(File).to have_received(:write).with(fake_schema_path, kind_of(String))
+          expect(File).to have_received(:write).with(default_schema_path, kind_of(String))
         end
       end
 
-      context 'when "GraphqlRouter" is not defined' do
-        it 'raises error' do
-          expect { call }.to raise_error(
-            'GraphqlRouter is missing. Run `rails g graphql_rails:install` to build it'
-          )
+      context 'when group name is given' do
+        let(:group) { 'custom' }
+
+        it 'writes router definition to group schema file' do
+          call
+          expected_path = "app/spec/fixtures/graphql_custom_schema.graphql"
+          expect(File).to have_received(:write).with(expected_path, kind_of(String))
+        end
+      end
+
+      context 'when GRAPHQL_SCHEMA_DUMP_PATH ENV variable is not set' do
+        it 'writes router definition to file' do
+          call
+          expect(File).to have_received(:write).with(default_schema_path, kind_of(String))
+        end
+      end
+
+      context 'when GRAPHQL_SCHEMA_DUMP_PATH ENV variable is set' do
+        let(:env_schema_path) { 'tmp/schema_path/env_schema.graphql' }
+
+        before do
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with('GRAPHQL_SCHEMA_DUMP_PATH').and_return(env_schema_path)
+          allow(File).to receive(:write).with(env_schema_path, kind_of(String)).and_return(1)
+        end
+
+        it 'writes router definition to file defined in ENV variable' do
+          call
+          expect(File).to have_received(:write).with(env_schema_path, kind_of(String))
+        end
+
+        it 'does not write router definition to default file' do
+          call
+          expect(File).not_to have_received(:write).with(default_schema_path, kind_of(String))
         end
       end
     end

--- a/spec/lib/graphql_rails/tasks/dump_graphql_schema_spec.rb
+++ b/spec/lib/graphql_rails/tasks/dump_graphql_schema_spec.rb
@@ -5,20 +5,18 @@ require 'graphql_rails/tasks/dump_graphql_schema'
 
 module GraphqlRails
   RSpec.describe DumpGraphqlSchema do
-    subject(:dump_graphql_schema) { described_class.new(group: group, router: graphql_router) }
+    subject(:dump_graphql_schema) do
+      described_class.new(group: group, router: graphql_router, dump_dir: 'app/graphql')
+    end
 
     let(:group) { nil }
-    let(:default_schema_path) { 'app/spec/fixtures/graphql_schema.graphql' }
+    let(:default_schema_path) { 'app/graphql/graphql_schema.graphql' }
 
     let(:graphql_router) do
       GraphqlRails::Router.draw {}
     end
 
     before do
-      # rubocop:disable RSpec/SubjectStub
-      allow(dump_graphql_schema).to receive(:root_path).and_return('app')
-      # rubocop:enable RSpec/SubjectStub
-
       allow(FileUtils).to receive(:mkdir_p).and_return(nil)
       allow(File).to receive(:write).and_return(1)
     end
@@ -38,35 +36,8 @@ module GraphqlRails
 
         it 'writes router definition to group schema file' do
           call
-          expected_path = "app/spec/fixtures/graphql_custom_schema.graphql"
+          expected_path = 'app/graphql/graphql_custom_schema.graphql'
           expect(File).to have_received(:write).with(expected_path, kind_of(String))
-        end
-      end
-
-      context 'when GRAPHQL_SCHEMA_DUMP_PATH ENV variable is not set' do
-        it 'writes router definition to file' do
-          call
-          expect(File).to have_received(:write).with(default_schema_path, kind_of(String))
-        end
-      end
-
-      context 'when GRAPHQL_SCHEMA_DUMP_PATH ENV variable is set' do
-        let(:env_schema_path) { 'tmp/schema_path/env_schema.graphql' }
-
-        before do
-          allow(ENV).to receive(:[]).and_call_original
-          allow(ENV).to receive(:[]).with('GRAPHQL_SCHEMA_DUMP_PATH').and_return(env_schema_path)
-          allow(File).to receive(:write).with(env_schema_path, kind_of(String)).and_return(1)
-        end
-
-        it 'writes router definition to file defined in ENV variable' do
-          call
-          expect(File).to have_received(:write).with(env_schema_path, kind_of(String))
-        end
-
-        it 'does not write router definition to default file' do
-          call
-          expect(File).not_to have_received(:write).with(default_schema_path, kind_of(String))
         end
       end
     end

--- a/spec/lib/graphql_rails/tasks/dump_graphql_schemas_spec.rb
+++ b/spec/lib/graphql_rails/tasks/dump_graphql_schemas_spec.rb
@@ -26,7 +26,7 @@ module GraphqlRails
         it 'dumps default schema', :aggregate_failures do
           call
           expect(DumpGraphqlSchema).to have_received(:call).once
-          expect(DumpGraphqlSchema).to have_received(:call).with(group: '', dump_dir: 'app/graphql')
+          expect(DumpGraphqlSchema).to have_received(:call).with(hash_including(group: ''))
         end
       end
 
@@ -36,8 +36,8 @@ module GraphqlRails
         it 'dumps default schema', :aggregate_failures do
           call
           expect(DumpGraphqlSchema).to have_received(:call).twice
-          expect(DumpGraphqlSchema).to have_received(:call).with(group: 'group1', dump_dir: 'app/graphql')
-          expect(DumpGraphqlSchema).to have_received(:call).with(group: 'group2', dump_dir: 'app/graphql')
+          expect(DumpGraphqlSchema).to have_received(:call).with(hash_including(group: 'group1'))
+          expect(DumpGraphqlSchema).to have_received(:call).with(hash_including(group: 'group2'))
         end
       end
 

--- a/spec/lib/graphql_rails/tasks/dump_graphql_schemas_spec.rb
+++ b/spec/lib/graphql_rails/tasks/dump_graphql_schemas_spec.rb
@@ -6,7 +6,7 @@ require 'graphql_rails/tasks/dump_graphql_schemas'
 
 module GraphqlRails
   RSpec.describe DumpGraphqlSchemas do
-    subject(:dump_graphql_schema) { described_class.new(groups: groups) }
+    subject(:dump_graphql_schema) { described_class.new(groups: groups, dump_dir: 'app/graphql') }
 
     let(:groups) { nil }
 
@@ -23,10 +23,21 @@ module GraphqlRails
       end
 
       context 'when groups are not given' do
-
-        it 'dumps default schema' do
+        it 'dumps default schema', :aggregate_failures do
           call
-          expect(DumpGraphqlSchema).to have_received(:call).with(group: '')
+          expect(DumpGraphqlSchema).to have_received(:call).once
+          expect(DumpGraphqlSchema).to have_received(:call).with(group: '', dump_dir: 'app/graphql')
+        end
+      end
+
+      context 'when groups are given' do
+        let(:groups) { %w[group1 group2] }
+
+        it 'dumps default schema', :aggregate_failures do
+          call
+          expect(DumpGraphqlSchema).to have_received(:call).twice
+          expect(DumpGraphqlSchema).to have_received(:call).with(group: 'group1', dump_dir: 'app/graphql')
+          expect(DumpGraphqlSchema).to have_received(:call).with(group: 'group2', dump_dir: 'app/graphql')
         end
       end
 

--- a/spec/lib/graphql_rails/tasks/dump_graphql_schemas_spec.rb
+++ b/spec/lib/graphql_rails/tasks/dump_graphql_schemas_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'graphql_rails/tasks/dump_graphql_schema'
+require 'graphql_rails/tasks/dump_graphql_schemas'
+
+module GraphqlRails
+  RSpec.describe DumpGraphqlSchemas do
+    subject(:dump_graphql_schema) { described_class.new(groups: groups) }
+
+    let(:groups) { nil }
+
+    describe '#call' do
+      subject(:call) { dump_graphql_schema.call }
+
+      let(:graphql_router) { GraphqlRails::Router.draw {} }
+
+      let(:stub_router_constant) { stub_const('GraphqlRouter', graphql_router) }
+
+      before do
+        allow(DumpGraphqlSchema).to receive(:call).and_return(nil)
+        stub_router_constant
+      end
+
+      context 'when groups are not given' do
+
+        it 'dumps default schema' do
+          call
+          expect(DumpGraphqlSchema).to have_received(:call).with(group: '')
+        end
+      end
+
+      context 'when "GraphqlRouter" is not defined' do
+        let(:stub_router_constant) { nil }
+
+        it 'raises error' do
+          expect { call }.to raise_error(
+            'GraphqlRouter is missing. Run `rails g graphql_rails:install` to build it'
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When project has multiple schemas, it's becomes annoying to update them only-by-one. This PR adds multiple group names support for `graphql_rails:schema:dump` rake task, so now we dump all schemas by default or we can specify specific multiple dumps like this:
`rake graphql_rails:schema:dump["group1, group2, ..., group99"]`