### PR TITLE
Make input attributes chainable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Added: support for generating multiple schema dumps with `rake graphql_rails:schema:dump`
+* Added: support for generating multiple schema dumps with `rake graphql_rails:schema:dump`.
+* Added: support for using chainable syntax for input attributes.
 * Changed: changed default `predicate method type from `Boolean` to `Boolean!`
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -361,6 +361,22 @@ class User
 end
 ```
 
+### "input.attribute" configuration with chainable methods
+
+If your input attribute definition is complex, you can define attribute in more eye-friendly chainable way with:
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql.input do |c|
+    c.attribute(:friends_count)
+      .type(:integer!)
+      .description('Can not be zero or less')
+  end
+end
+```
+
 #### required type
 
 There are few ways how to mark field as required.

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -243,6 +243,24 @@ class User
 end
 ```
 
+### attribute.with
+
+When you want to define some options dynamically, it's quite handy to use "Attribute#with" method:
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    c.attribute(:shop_id).with(type: 'ID', description: 'references to shop')
+    # same as:
+    # c.attribute(:shop_id, type: 'ID', description: 'references to shop')
+    # also same as:
+    # c.attribute(:shop_id).type('ID').description('references to shop')
+  end
+end
+```
+
 ### "attribute" configuration with chainable methods
 
 If your attribute definition is complex, you can define attribute in more eye-friendly chainable way with:

--- a/lib/graphql_rails/attributes/attributable.rb
+++ b/lib/graphql_rails/attributes/attributable.rb
@@ -6,14 +6,14 @@ require 'graphql_rails/attributes/attribute_name_parser'
 module GraphqlRails
   module Attributes
     # contains methods which are shared between various attribute-like classes
-    # expects `initial_name` and `initial_type` to be defined
+    # expects `initial_name` and `type` to be defined
     module Attributable
       def field_name
         attribute_name_parser.field_name
       end
 
       def type_name
-        @type_name ||= initial_type.to_s
+        type.to_s
       end
 
       def name
@@ -23,19 +23,9 @@ module GraphqlRails
       def required?
         return @required unless @required.nil?
 
-        (initial_type.nil? && attribute_name_parser.required?) ||
-          initial_type.to_s[/!$/].present? ||
-          initial_type.is_a?(GraphQL::Schema::NonNull)
-      end
-
-      def required
-        @required = true
-        self
-      end
-
-      def optional
-        @required = false
-        self
+        (type.nil? && attribute_name_parser.required?) ||
+          type.to_s[/!$/].present? ||
+          type.is_a?(GraphQL::Schema::NonNull)
       end
 
       def graphql_model
@@ -54,7 +44,7 @@ module GraphqlRails
 
       def type_parser
         @type_parser ||= begin
-          type_for_parser = initial_type || attribute_name_parser.graphql_type
+          type_for_parser = type || attribute_name_parser.graphql_type
           TypeParser.new(type_for_parser, paginated: paginated?)
         end
       end

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -21,10 +21,10 @@ module GraphqlRails
         @attributes ||= {}
       end
 
-      def property(new_property = NOT_SET)
-        return @property if new_property == NOT_SET
+      def property(new_value = NOT_SET)
+        return @property if new_value == NOT_SET
 
-        @property = new_property.to_s
+        @property = new_value.to_s
         self
       end
 

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -2,6 +2,7 @@
 
 require 'graphql'
 require 'graphql_rails/attributes/attributable'
+require 'graphql_rails/attributes/attribute_configurable'
 require 'graphql_rails/input_configurable'
 
 module GraphqlRails
@@ -9,47 +10,21 @@ module GraphqlRails
     # contains info about single graphql attribute
     class Attribute
       include Attributable
+      include AttributeConfigurable
       include InputConfigurable
 
       attr_reader :attributes
 
-      # rubocop:disable Metrics/ParameterLists
-      def initialize(name, type = nil, description: nil, property: name, required: nil, options: {})
-        @initial_type = type
+      def initialize(name)
         @initial_name = name
-        @options = options
-        @description = description
-        @property = property.to_s
-        @required = required
+        @property = name.to_s
         @attributes ||= {}
       end
-      # rubocop:enable Metrics/ParameterLists
 
-      def type(new_type = nil)
-        return @initial_type if new_type.nil?
-
-        @initial_type = new_type
-        self
-      end
-
-      def description(new_description = nil)
-        return @description if new_description.nil?
-
-        @description = new_description
-        self
-      end
-
-      def property(new_property = nil)
-        return @property if new_property.nil?
+      def property(new_property = NOT_SET)
+        return @property if new_property == NOT_SET
 
         @property = new_property.to_s
-        self
-      end
-
-      def options(new_options = {})
-        return @options if new_options.blank?
-
-        @options = new_options
         self
       end
 
@@ -82,7 +57,7 @@ module GraphqlRails
 
       protected
 
-      attr_reader :initial_type, :initial_name
+      attr_reader :initial_name
 
       private
 

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -3,20 +3,21 @@
 require 'graphql_rails/attributes/type_parser'
 require 'graphql_rails/attributes/attribute_name_parser'
 require 'graphql_rails/model/build_enum_type'
+require 'graphql_rails/concerns/chainable_options'
+require 'active_support/concern'
 
 module GraphqlRails
   module Attributes
     # Allows to set or get various attribute parameters
     module AttributeConfigurable
-      NOT_SET = Object.new
+      extend ActiveSupport::Concern
 
-      def with(**attribute_options)
-        attribute_options.each do |method_name, args|
-          send_args = [method_name]
-          send_args << args if method(method_name).parameters.present?
-          public_send(*send_args)
-        end
-        self
+      included do
+        include GraphqlRails::ChainableOptions
+
+        chainable_option :description
+        chainable_option :options, default: {}
+        chainable_option :type
       end
 
       def required(new_value = true) # rubocop:disable Style/OptionalBooleanParameter
@@ -26,28 +27,6 @@ module GraphqlRails
 
       def optional(new_value = true) # rubocop:disable Style/OptionalBooleanParameter
         required(!new_value)
-      end
-
-      def type(new_type = NOT_SET)
-        return @type if new_type == NOT_SET
-
-        @type = new_type
-        self
-      end
-
-      def description(new_description = NOT_SET)
-        return @description if new_description == NOT_SET
-
-        @description = new_description
-        self
-      end
-
-      def options(new_options = NOT_SET)
-        @options ||= {}
-        return @options if new_options == NOT_SET
-
-        @options = new_options
-        self
       end
     end
   end

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'graphql_rails/attributes/type_parser'
+require 'graphql_rails/attributes/attribute_name_parser'
+require 'graphql_rails/model/build_enum_type'
+
+module GraphqlRails
+  module Attributes
+    # Allows to set or get various attribute parameters
+    module AttributeConfigurable
+      NOT_SET = Object.new
+
+      def with(**attribute_options)
+        attribute_options.each do |method_name, args|
+          send_args = [method_name]
+          send_args << args if method(method_name).parameters.present?
+          public_send(*send_args)
+        end
+        self
+      end
+
+      def required(new_value = true) # rubocop:disable Style/OptionalBooleanParameter
+        @required = new_value
+        self
+      end
+
+      def optional(new_value = true) # rubocop:disable Style/OptionalBooleanParameter
+        required(!new_value)
+      end
+
+      def type(new_type = NOT_SET)
+        return @type if new_type == NOT_SET
+
+        @type = new_type
+        self
+      end
+
+      def description(new_description = NOT_SET)
+        return @description if new_description == NOT_SET
+
+        @description = new_description
+        self
+      end
+
+      def options(new_options = NOT_SET)
+        @options ||= {}
+        return @options if new_options == NOT_SET
+
+        @options = new_options
+        self
+      end
+    end
+  end
+end

--- a/lib/graphql_rails/attributes/input_attribute.rb
+++ b/lib/graphql_rails/attributes/input_attribute.rb
@@ -9,6 +9,9 @@ module GraphqlRails
       include Attributable
       include AttributeConfigurable
 
+      chainable_option :subtype
+      chainable_option :enum
+
       def initialize(name)
         @initial_name = name
       end
@@ -21,20 +24,6 @@ module GraphqlRails
 
       def input_argument_options
         { required: required?, description: description, camelize: false }
-      end
-
-      def subtype(new_value = NOT_SET)
-        return @subtype if new_value == NOT_SET
-
-        @subtype = new_value
-        self
-      end
-
-      def enum(*enum_values)
-        return @enum if enum_values.empty?
-
-        @enum = enum_values.flatten
-        self
       end
 
       def paginated?

--- a/lib/graphql_rails/attributes/input_attribute.rb
+++ b/lib/graphql_rails/attributes/input_attribute.rb
@@ -4,6 +4,7 @@ module GraphqlRails
   module Attributes
     # contains info about single graphql input attribute
     class InputAttribute
+      require 'graphql_rails/model/build_enum_type'
       require_relative './input_type_parser'
       require_relative './attribute_name_parser'
       include Attributable
@@ -12,7 +13,8 @@ module GraphqlRails
       chainable_option :subtype
       chainable_option :enum
 
-      def initialize(name)
+      def initialize(name, config:)
+        @config = config
         @initial_name = name
       end
 
@@ -32,7 +34,7 @@ module GraphqlRails
 
       private
 
-      attr_reader :initial_name
+      attr_reader :initial_name, :config
 
       def attribute_name_parser
         @attribute_name_parser ||= AttributeNameParser.new(
@@ -54,8 +56,8 @@ module GraphqlRails
       def enum_type
         return if enum.blank?
 
-        BuildEnumType.call(
-          "#{name}_#{attribute_name}_enum",
+        ::GraphqlRails::Model::BuildEnumType.call(
+          "#{config.name}_#{initial_name}_enum",
           allowed_values: enum
         )
       end

--- a/lib/graphql_rails/concerns/chainable_options.rb
+++ b/lib/graphql_rails/concerns/chainable_options.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module GraphqlRails
+  # Allows defining methods chained way
+  module ChainableOptions
+    NOT_SET = Object.new
+
+    # nodoc
+    module ClassMethods
+      def chainable_option(option_name, default: nil)
+        define_method(option_name) do |value = NOT_SET|
+          get_or_set_chainable_option(option_name, value, default: default)
+        end
+      end
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    def initialize_copy(other)
+      super
+      @chainable_option = other.instance_variable_get(:@chainable_option).dup
+    end
+
+    def with(**options)
+      options.each do |method_name, args|
+        send_args = [method_name]
+        send_args << args if method(method_name).parameters.present?
+        public_send(*send_args)
+      end
+      self
+    end
+
+    private
+
+    def fetch_chainable_option(option_name, *default, &block)
+      @chainable_option.fetch(option_name.to_sym, *default, &block)
+    end
+
+    def get_or_set_chainable_option(option_name, value = NOT_SET, default: nil)
+      @chainable_option ||= {}
+      return fetch_chainable_option(option_name, default) if value == NOT_SET
+
+      @chainable_option[option_name.to_sym] = value
+      self
+    end
+  end
+end

--- a/lib/graphql_rails/input_configurable.rb
+++ b/lib/graphql_rails/input_configurable.rb
@@ -43,7 +43,7 @@ module GraphqlRails
 
     def build_input_attribute(name, options: {}, **other_options)
       input_options = input_attribute_options.merge(options)
-      Attributes::InputAttribute.new(name.to_s).with(options: input_options, **other_options)
+      Attributes::InputAttribute.new(name.to_s, config: self).with(options: input_options, **other_options)
     end
   end
 end

--- a/lib/graphql_rails/input_configurable.rb
+++ b/lib/graphql_rails/input_configurable.rb
@@ -42,11 +42,8 @@ module GraphqlRails
     end
 
     def build_input_attribute(name, options: {}, **other_options)
-      Attributes::InputAttribute.new(
-        name.to_s,
-        options: input_attribute_options.merge(options),
-        **other_options
-      )
+      input_options = input_attribute_options.merge(options)
+      Attributes::InputAttribute.new(name.to_s).with(options: input_options, **other_options)
     end
   end
 end

--- a/lib/graphql_rails/model/configurable.rb
+++ b/lib/graphql_rails/model/configurable.rb
@@ -5,11 +5,20 @@ module GraphqlRails
     # contains methods which are shared between various configurations
     # expects `default_name` to be defined
     module Configurable
+      require 'active_support/concern'
+      require 'graphql_rails/concerns/chainable_options'
+
+      extend ActiveSupport::Concern
+
+      included do
+        include GraphqlRails::ChainableOptions
+
+        chainable_option :description
+      end
+
       def initialize_copy(other)
         super
-        @name = nil
         @type_name = nil
-        @description = nil
         @attributes = other.attributes.transform_values(&:dup)
       end
 
@@ -17,18 +26,12 @@ module GraphqlRails
         @attributes ||= {}
       end
 
-      def name(graphql_name = nil)
-        @name = graphql_name if graphql_name
-        @name || default_name
+      def name(*args)
+        get_or_set_chainable_option(:name, *args) || default_name
       end
 
       def type_name
         @type_name ||= "#{name.camelize}Type#{SecureRandom.hex}"
-      end
-
-      def description(new_description = nil)
-        @description = new_description if new_description
-        @description
       end
 
       def attribute(attribute_name, **attribute_options)

--- a/lib/graphql_rails/model/configurable.rb
+++ b/lib/graphql_rails/model/configurable.rb
@@ -2,8 +2,10 @@
 
 module GraphqlRails
   module Model
-    # contains methods which are shared between various configurations
-    # expects `default_name` to be defined
+    # Contains methods which are shared between various configurations.
+    #
+    # Expects `default_name` to be defined.
+    # Expects `build_attribute(attr_name)` method to be defined.
     module Configurable
       require 'active_support/concern'
       require 'graphql_rails/concerns/chainable_options'
@@ -38,15 +40,9 @@ module GraphqlRails
         key = attribute_name.to_s
 
         attributes[key] ||= build_attribute(attribute_name).tap do |new_attribute|
-          new_attribute.with(attribute_options)
+          new_attribute.with(**attribute_options) unless attribute_options.empty?
           yield(new_attribute) if block_given?
         end
-      end
-
-      private
-
-      def build_attribute(_name)
-        raise NotImplementedError
       end
     end
   end

--- a/lib/graphql_rails/model/configurable.rb
+++ b/lib/graphql_rails/model/configurable.rb
@@ -30,6 +30,21 @@ module GraphqlRails
         @description = new_description if new_description
         @description
       end
+
+      def attribute(attribute_name, **attribute_options)
+        key = attribute_name.to_s
+
+        attributes[key] ||= build_attribute(attribute_name).tap do |new_attribute|
+          new_attribute.with(attribute_options)
+          yield(new_attribute) if block_given?
+        end
+      end
+
+      private
+
+      def build_attribute(_name)
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/graphql_rails/model/configuration.rb
+++ b/lib/graphql_rails/model/configuration.rb
@@ -2,7 +2,6 @@
 
 require 'graphql_rails/attributes'
 require 'graphql_rails/model/find_or_build_graphql_type'
-require 'graphql_rails/model/build_enum_type'
 require 'graphql_rails/model/input'
 require 'graphql_rails/model/configurable'
 require 'graphql_rails/model/build_connection_type'
@@ -11,6 +10,7 @@ module GraphqlRails
   module Model
     # stores information about model specific config, like attributes and types
     class Configuration
+      include ChainableOptions
       include Configurable
 
       def initialize(model_class)

--- a/lib/graphql_rails/model/configuration.rb
+++ b/lib/graphql_rails/model/configuration.rb
@@ -27,16 +27,9 @@ module GraphqlRails
       def attribute(attribute_name, **attribute_options)
         key = attribute_name.to_s
 
-        attributes[key] ||= Attributes::Attribute.new(attribute_name)
-
-        attributes[key].tap do |attribute|
-          attribute_options.each do |method_name, args|
-            send_args = [method_name]
-            send_args << args if attribute.method(method_name).parameters.present?
-            attribute.public_send(*send_args)
-          end
-
-          yield(attribute) if block_given?
+        attributes[key] ||= build_attribute(attribute_name).tap do |new_attribute|
+          new_attribute.with(**attribute_options)
+          yield(new_attribute) if block_given?
         end
       end
 
@@ -78,6 +71,10 @@ module GraphqlRails
       private
 
       attr_reader :model_class
+
+      def build_attribute(attribute_name)
+        Attributes::Attribute.new(attribute_name)
+      end
 
       def default_name
         @default_name ||= model_class.name.split('::').last

--- a/lib/graphql_rails/model/input.rb
+++ b/lib/graphql_rails/model/input.rb
@@ -23,30 +23,12 @@ module GraphqlRails
         )
       end
 
-      def attribute(attribute_name, type: nil, enum: nil, **attribute_options)
-        input_type = attribute_type(attribute_name, type: type, enum: enum, **attribute_options)
-
-        attributes[attribute_name.to_s] = \
-          Attributes::InputAttribute.new(attribute_name).with(type: input_type, **attribute_options)
-      end
-
-      def enum(*enum_values)
-        values = enum_values.flatten
-
-        enum_type = BuildEnumType.call(
-          "#{name}_#{attribute_name}_enum",
-          allowed_values: values,
-          description: description
-        )
-        type(enum_type)
-      end
-
       private
 
       attr_reader :input_name_suffix, :model_class
 
       def build_attribute(attribute_name)
-        Attributes::InputAttribute.new(attribute_name)
+        Attributes::InputAttribute.new(attribute_name, config: self)
       end
 
       def default_name
@@ -54,16 +36,6 @@ module GraphqlRails
           suffix = input_name_suffix ? input_name_suffix.to_s.camelize : ''
           "#{model_class.name.split('::').last}#{suffix}Input"
         end
-      end
-
-      def attribute_type(attribute_name, type:, enum:, description: nil, **_other)
-        return type unless enum
-
-        BuildEnumType.call(
-          "#{name}_#{attribute_name}_enum",
-          allowed_values: enum,
-          description: description
-        )
       end
     end
   end

--- a/lib/graphql_rails/model/input.rb
+++ b/lib/graphql_rails/model/input.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
-require 'graphql_rails/model/build_graphql_input_type'
-require 'graphql_rails/model/configurable'
-
 module GraphqlRails
   module Model
     # stores information about model input specific config, like attributes and types
     class Input
+      require 'graphql_rails/concerns/chainable_options'
+      require 'graphql_rails/model/configurable'
+      require 'graphql_rails/model/build_graphql_input_type'
+
       include Configurable
+
+      chainable_option :enum
 
       def initialize(model_class, input_name_suffix)
         @model_class = model_class

--- a/lib/graphql_rails/model/input.rb
+++ b/lib/graphql_rails/model/input.rb
@@ -23,14 +23,28 @@ module GraphqlRails
       def attribute(attribute_name, type: nil, enum: nil, **attribute_options)
         input_type = attribute_type(attribute_name, type: type, enum: enum, **attribute_options)
 
-        attributes[attribute_name.to_s] = Attributes::InputAttribute.new(
-          attribute_name, type: input_type, **attribute_options
+        attributes[attribute_name.to_s] = \
+          Attributes::InputAttribute.new(attribute_name).with(type: input_type, **attribute_options)
+      end
+
+      def enum(*enum_values)
+        values = enum_values.flatten
+
+        enum_type = BuildEnumType.call(
+          "#{name}_#{attribute_name}_enum",
+          allowed_values: values,
+          description: description
         )
+        type(enum_type)
       end
 
       private
 
       attr_reader :input_name_suffix, :model_class
+
+      def build_attribute(attribute_name)
+        Attributes::InputAttribute.new(attribute_name)
+      end
 
       def default_name
         @default_name ||= begin

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -49,6 +49,12 @@ module GraphqlRails
         end
       end
 
+      describe '#type_name' do
+        it 'returns stringified type name' do
+          expect(attribute.type_name).to eq 'String!'
+        end
+      end
+
       describe '#field_args' do
         subject(:field_args) { attribute.field_args }
 

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module GraphqlRails
   module Attributes
     RSpec.describe Attribute do
-      subject(:attribute) { described_class.new(name, type, options: options) }
+      subject(:attribute) { described_class.new(name).with(type: type, options: options) }
 
       let(:type) { 'String!' }
       let(:name) { 'full_name' }

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -5,17 +5,54 @@ require 'spec_helper'
 module GraphqlRails
   module Attributes
     RSpec.describe InputAttribute do
-      subject(:attribute) { described_class.new(name, type: type, options: options) }
+      subject(:attribute) { described_class.new(name).with(type: type, options: options) }
 
       let(:type) { 'String!' }
       let(:name) { 'full_name' }
       let(:options) { {} }
 
-      class DummyModel
-        include GraphqlRails::Model
+      let(:dummy_model) do
+        Class.new do
+          include GraphqlRails::Model
 
-        graphql.input do |c|
-          c.attribute :name
+          graphql.input do |c|
+            c.attribute :name
+          end
+
+          def self.name
+            'DummyModel'
+          end
+        end
+      end
+
+      before do
+        stub_const('DummyModel', dummy_model)
+      end
+
+      describe '#type' do
+        it 'changes input type' do
+          expect { attribute.type(:int!) }.to change(attribute, :type).to(:int!)
+        end
+      end
+
+      describe '#description' do
+        it 'changes input type' do
+          expect { attribute.description('this is my input') }
+            .to change(attribute, :description).to('this is my input')
+        end
+      end
+
+      describe '#enum' do
+        it 'changes input type' do
+          expect { attribute.enum('this', 'is', 'enum') }
+            .to change(attribute, :enum).to(%w[this is enum])
+        end
+      end
+
+      describe '#subtype' do
+        it 'changes subtype' do
+          expect { attribute.subtype('update') }
+            .to change(attribute, :subtype).to('update')
         end
       end
 
@@ -38,7 +75,7 @@ module GraphqlRails
 
         context 'when type is instance of GrapqhlRails::Input' do
           let(:type) do
-            DummyModel.graphql.input(:dummy_input) {}
+            dummy_model.graphql.input(:dummy_input) {}
           end
 
           it 'returns graphql input type' do
@@ -75,16 +112,16 @@ module GraphqlRails
         end
 
         context 'when type refers to Graphql::Model' do
-          let(:type) { DummyModel.name }
+          let(:type) { dummy_model.name }
 
           context 'when type is nullable' do
             it 'returns graphql input type' do
-              expect(input_argument_type).to eq DummyModel.graphql.input.graphql_input_type
+              expect(input_argument_type).to eq dummy_model.graphql.input.graphql_input_type
             end
           end
 
           context 'when type is not nullable' do
-            let(:type) { "#{DummyModel.name}!" }
+            let(:type) { "#{dummy_model.name}!" }
 
             it 'returns non nullable graphql input type' do
               expect(input_argument_type.to_type_signature).to eq 'DummyModelInput'
@@ -96,7 +133,7 @@ module GraphqlRails
           end
 
           context 'when type is not nullable array' do
-            let(:type) { "[#{DummyModel.name}!]!" }
+            let(:type) { "[#{dummy_model.name}!]!" }
 
             it 'retuns as an array' do
               expect(input_argument_type).to be_an(Array)
@@ -126,7 +163,7 @@ module GraphqlRails
           end
 
           context 'when type is nullable array' do
-            let(:type) { "[#{DummyModel.name}!]" }
+            let(:type) { "[#{dummy_model.name}!]" }
 
             it 'contains required inner type', :aggregate_failures do
               expect(input_argument_type.first.to_type_signature).to eq 'DummyModelInput'

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -44,7 +44,7 @@ module GraphqlRails
 
       describe '#enum' do
         it 'changes input type' do
-          expect { attribute.enum('this', 'is', 'enum') }
+          expect { attribute.enum(%w[this is enum]) }
             .to change(attribute, :enum).to(%w[this is enum])
         end
       end

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -5,8 +5,12 @@ require 'spec_helper'
 module GraphqlRails
   module Attributes
     RSpec.describe InputAttribute do
-      subject(:attribute) { described_class.new(name).with(type: type, options: options) }
+      subject(:attribute) do
+        described_class.new(name, config: config)
+                       .with(type: type, options: options)
+      end
 
+      let(:config) { instance_double('GraphqlRails::Model::Input', name: 'DummyInput') }
       let(:type) { 'String!' }
       let(:name) { 'full_name' }
       let(:options) { {} }

--- a/spec/lib/graphql_rails/model/graphql_input_type_builder_spec.rb
+++ b/spec/lib/graphql_rails/model/graphql_input_type_builder_spec.rb
@@ -11,8 +11,8 @@ module GraphqlRails
       let(:description) { 'This is dummy input' }
       let(:attributes) do
         {
-          id: GraphqlRails::Attributes::InputAttribute.new(:id),
-          full_name: GraphqlRails::Attributes::InputAttribute.new(:full_name!)
+          id: GraphqlRails::Attributes::InputAttribute.new(:id, config: nil),
+          full_name: GraphqlRails::Attributes::InputAttribute.new(:full_name!, config: nil)
         }
       end
 


### PR DESCRIPTION
Currently it's possible to define graphql.attribute in a chainable way like this:
```ruby
graphql do |c|
  c.attribute(:first_name)
    .type(:string!)
    .description('...')
end
```

but this does not work with input attributes. This makes graphql attribute behavior inconsistent.

This PR adds chainable syntax support for `graphql.input.attribute`, so this will be also possible:
```ruby
graphql.input do |c|
  c.attribute(:first_name)
    .type(:string!)
    .description('...')
end
```
