### PR TITLE
Change default predicate method type to be non-nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added: support for generating multiple schema dumps with `rake graphql_rails:schema:dump`
+* Changed: changed default `predicate method type from `Boolean` to `Boolean!`
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [1.2.4](2021-05-05)

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -27,8 +27,8 @@ Most commonly you will use `attribute` to make your model methods and attributes
 
 Some types can be determined by attribute name, so you can skip this attribute:
 
-* attributes which ends with name `*_id` has `ID` type
-* attributes which ends with `?` has `Boolean` type
+* attributes which ends with name `*_id` has `ID!` type
+* attributes which ends with `?` has `Boolean!` type
 * all other attributes without type are considered to be `String`
 
 available types are:
@@ -45,9 +45,9 @@ class User
   include GraphqlRails::Model
 
   graphql do |c|
-    c.attribute :shop_id # ID type
+    c.attribute :shop_id # ID! type
     c.attribute :full_name # String type
-    c.attribute :admin? # Boolean type
+    c.attribute :admin? # Boolean! type
     c.attribute :level, type: 'integer'
     c.attribute :money, type: 'float'
   end

--- a/lib/graphql_rails/attributes/attributable.rb
+++ b/lib/graphql_rails/attributes/attributable.rb
@@ -23,7 +23,7 @@ module GraphqlRails
       def required?
         return @required unless @required.nil?
 
-        attribute_name_parser.required? || !initial_type.to_s[/!$/].nil? || initial_type.is_a?(GraphQL::Schema::NonNull)
+        (initial_type.nil? && attribute_name_parser.required?) || !initial_type.to_s[/!$/].nil? || initial_type.is_a?(GraphQL::Schema::NonNull)
       end
 
       def required

--- a/lib/graphql_rails/attributes/attributable.rb
+++ b/lib/graphql_rails/attributes/attributable.rb
@@ -23,7 +23,9 @@ module GraphqlRails
       def required?
         return @required unless @required.nil?
 
-        (initial_type.nil? && attribute_name_parser.required?) || !initial_type.to_s[/!$/].nil? || initial_type.is_a?(GraphQL::Schema::NonNull)
+        (initial_type.nil? && attribute_name_parser.required?) ||
+          initial_type.to_s[/!$/].present? ||
+          initial_type.is_a?(GraphQL::Schema::NonNull)
       end
 
       def required

--- a/lib/graphql_rails/attributes/attribute_name_parser.rb
+++ b/lib/graphql_rails/attributes/attribute_name_parser.rb
@@ -5,12 +5,8 @@ module GraphqlRails
     # Parses attribute name and can generates graphql scalar type,
     # grapqhl name and etc. based on that
     class AttributeNameParser
-      attr_reader :name
-
       def initialize(original_name, options: {})
-        name = original_name.to_s
-        @required = !name['!'].nil?
-        @name = name.tr('!', '')
+        @original_name = original_name.to_s
         @options = options
       end
 
@@ -36,12 +32,16 @@ module GraphqlRails
       end
 
       def required?
-        @required
+        original_name['!'].present? || original_name.ends_with?('?')
+      end
+
+      def name
+        @name ||= original_name.tr('!', '')
       end
 
       private
 
-      attr_reader :options
+      attr_reader :options, :original_name
 
       def original_format?
         options[:input_format] == :original || options[:attribute_name_format] == :original

--- a/spec/lib/graphql_rails/controller/action_configuration_spec.rb
+++ b/spec/lib/graphql_rails/controller/action_configuration_spec.rb
@@ -75,19 +75,29 @@ module GraphqlRails
         subject(:permitted_attribute_args) { config.attributes['name'].input_argument_args }
 
         let(:permitted_attribute_options) { config.attributes['name'].input_argument_options }
+        let(:permit_args) { [] }
         let(:permit_params) { { attribute_name => attribute_type } }
         let(:attribute_name) { :name }
         let(:attribute_type) { 'string' }
 
         before do
-          config.permit(**permit_params)
+          config.permit(*permit_args, **permit_params)
         end
 
         context 'when attribute name has bang at the end' do
-          let(:attribute_name) { :name! }
+          let(:permit_args) { :name! }
+          let(:permit_params) { {} }
 
           it 'sets attribute as required' do
             expect(permitted_attribute_options[:required]).to be true
+          end
+        end
+
+        context 'when attribute name has bang at the end but type does not have bang' do
+          let(:attribute_name) { :name! }
+
+          it 'sets attribute as optional' do
+            expect(permitted_attribute_options[:required]).to be false
           end
         end
 


### PR DESCRIPTION
# Current behavior

In most cases, predicate methods return only `true` or `false` values, but by default `GraphqlRails` sets this type to `Boolean` which indicates that value might be `null` too.

```ruby
graphql do |c|
  c.attribute(:enabled?) # sets `Boolean` type based on name
end
```

# New behavior

This PR changes this default value to always be non-nullable:
```ruby
graphql do |c|
  c.attribute(:enabled?) # sets `Boolean!` type based on name
end
```