### PR TITLE
Include type name when raising error for types without pagination support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added: support for generating multiple schema dumps with `rake graphql_rails:schema:dump`.
 * Added: support for using chainable syntax for input attributes.
 * Changed: changed default `predicate method type from `Boolean` to `Boolean!`
+* Changed: changed error message when trying to paginate not supported types
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [1.2.4](2021-05-05)

--- a/lib/graphql_rails/attributes/type_parser.rb
+++ b/lib/graphql_rails/attributes/type_parser.rb
@@ -51,7 +51,9 @@ module GraphqlRails
       def paginated_type_arg
         return graphql_model.graphql.connection_type if graphql_model
 
-        raise NotSupportedFeature, 'pagination is only supported for models which include GraphqlRails::Model'
+        error_message = "Unable to paginate #{unparsed_type.inspect}. " \
+                        'Pagination is only supported for models which include GraphqlRails::Model'
+        raise NotSupportedFeature, error_message
       end
 
       def list_type_arg

--- a/spec/lib/graphql_rails/attributes/type_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/type_parser_spec.rb
@@ -12,7 +12,7 @@ module GraphqlRails
       describe '#graphql_model' do
         subject(:graphql_model) { parser.graphql_model }
 
-        context 'when costom type is provided' do
+        context 'when custom type is provided' do
           let(:type) { 'SomeImage' }
 
           it 'returns custom model' do
@@ -55,7 +55,7 @@ module GraphqlRails
             context 'when array is required' do
               let(:type) { '[String]!' }
 
-              it 'returns correct structore' do
+              it 'returns correct structure' do
                 expect(type_arg).to eq([GraphQL::Types::String, { null: true }])
               end
             end
@@ -63,9 +63,35 @@ module GraphqlRails
             context 'when array is optional' do
               let(:type) { '[String]' }
 
-              it 'returns correct structore' do
+              it 'returns correct structure' do
                 expect(type_arg).to eq([GraphQL::Types::String, { null: true }])
               end
+            end
+          end
+        end
+
+        context 'when pagination is enabled' do
+          let(:parser) { described_class.new(type, paginated: true) }
+
+          context 'when type is not GraphqlRails::Model' do
+            let(:type) { '[String!]!' }
+
+            it 'raises error' do
+              expect { type_arg }.to raise_error(/Unable to paginate "\[String!\]!"/)
+            end
+          end
+
+          context 'when graphql_rails model is provided' do
+            let(:type) do
+              Class.new do
+                include GraphqlRails::Model
+                graphql.name 'Dummy'
+                graphql.attribute(:name)
+              end
+            end
+
+            it 'returns connection' do
+              expect(type_arg < GraphQL::Types::Relay::BaseConnection).to be true
             end
           end
         end


### PR DESCRIPTION
It's almost impossible to understand where is the issue when the `NotSupportedFeature` error is raised without any hint to type. This PR includes type name in error message