### PR TITLE
Allow dynamically defining graphql-ruby types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added: support for using chainable syntax for input attributes.
 * Changed: changed default `predicate method type from `Boolean` to `Boolean!`
 * Changed: changed error message when trying to paginate not supported types
+* Added: support defining graphql-ruby types as strings.
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [1.2.4](2021-05-05)

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -72,7 +72,7 @@ end
 class User
   include GraphqlRails::Model
 
-  graphql.attribute :address, type: AddressType, required: true
+  graphql.attribute :address, type: 'AddressType!', required: true
 end
 ```
 

--- a/lib/graphql_rails/attributes/attribute_name_parser.rb
+++ b/lib/graphql_rails/attributes/attribute_name_parser.rb
@@ -32,7 +32,7 @@ module GraphqlRails
       end
 
       def required?
-        original_name['!'].present? || original_name.ends_with?('?')
+        original_name['!'].present? || original_name.end_with?('?')
       end
 
       def name

--- a/lib/graphql_rails/attributes/input_type_parser.rb
+++ b/lib/graphql_rails/attributes/input_type_parser.rb
@@ -15,12 +15,6 @@ module GraphqlRails
         @subtype = subtype
       end
 
-      def graphql_type
-        return nil if unparsed_type.nil?
-
-        partly_parsed_type || parsed_type
-      end
-
       def input_type_arg
         if list?
           list_type_arg
@@ -34,7 +28,11 @@ module GraphqlRails
       attr_reader :unparsed_type, :subtype
 
       def unwrapped_type
-        raw_unwrapped_type || unwrapped_scalar_type || unwrapped_model_input_type || raise_not_supported_type_error
+        raw_unwrapped_type ||
+          unwrapped_scalar_type ||
+          unwrapped_model_input_type ||
+          graphql_type_object ||
+          raise_not_supported_type_error
       end
 
       def raw_unwrapped_type

--- a/lib/graphql_rails/attributes/type_parser.rb
+++ b/lib/graphql_rails/attributes/type_parser.rb
@@ -109,14 +109,7 @@ module GraphqlRails
       end
 
       def type_by_name
-        unwrapped_scalar_type || unwrapped_model_type || raise_not_supported_type_error
-      end
-
-      def unwrapped_model_type
-        type_class = graphql_model
-        return unless type_class
-
-        type_class.graphql.graphql_type
+        unwrapped_scalar_type || graphql_type_object || raise_not_supported_type_error
       end
     end
   end

--- a/lib/graphql_rails/model/find_or_build_graphql_type.rb
+++ b/lib/graphql_rails/model/find_or_build_graphql_type.rb
@@ -37,28 +37,29 @@ module GraphqlRails
       end
 
       def add_fields_to_graphql_type
-        AddFieldsToGraphqlType.call(klass: klass, attributes: attributes.values.select(&:scalar_type?))
+        scalar_attributes, dynamic_attributes = attributes.values.partition(&:scalar_type?)
 
-        attributes.values.reject(&:scalar_type?).tap do |dynamic_attributes|
-          find_or_build_dynamic_graphql_types(dynamic_attributes) do |name, description, attributes, type_name|
-            self.class.call(
-              name: name, description: description,
-              attributes: attributes, type_name: type_name
-            )
-          end
-          AddFieldsToGraphqlType.call(klass: klass, attributes: dynamic_attributes)
+        AddFieldsToGraphqlType.call(klass: klass, attributes: scalar_attributes)
+        dynamic_attributes.each { |attribute| find_or_build_dynamic_type(attribute) }
+        AddFieldsToGraphqlType.call(klass: klass, attributes: dynamic_attributes)
+      end
+
+      def find_or_build_dynamic_type(attribute)
+        graphql_model = attribute.graphql_model
+        if graphql_model
+          find_or_build_graphql_model_type(graphql_model)
+        else
+          AddFieldsToGraphqlType.call(klass: klass, attributes: [attribute])
         end
       end
 
-      def find_or_build_dynamic_graphql_types(dynamic_attributes)
-        dynamic_attributes.each do |attribute|
-          yield(
-            attribute.graphql_model.graphql.name,
-            attribute.graphql_model.graphql.description,
-            attribute.graphql_model.graphql.attributes,
-            attribute.graphql_model.graphql.type_name
-          )
-        end
+      def find_or_build_graphql_model_type(graphql_model)
+        self.class.call(
+          name: graphql_model.graphql.name,
+          description: graphql_model.graphql.description,
+          attributes: graphql_model.graphql.attributes,
+          type_name: graphql_model.graphql.type_name
+        )
       end
     end
   end

--- a/spec/lib/graphql_rails/attributes/input_type_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_type_parser_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module GraphqlRails
+  module Attributes
+    RSpec.describe InputTypeParser do
+      subject(:parser) { described_class.new(type, subtype: subtype) }
+
+      let(:subtype) { nil }
+      let(:type) { 'String!' }
+
+      describe '#graphql_model' do
+        subject(:graphql_model) { parser.graphql_model }
+
+        context 'when custom type is provided' do
+          let(:type) { 'SomeImage' }
+
+          it 'returns custom model' do
+            image = Object.const_set('SomeImage', Class.new { include GraphqlRails::Model })
+            expect(graphql_model).to eq(image)
+          end
+        end
+
+        context 'when graphql type is provided' do
+          let(:type) { GraphQL::Types::Int }
+
+          it { is_expected.to be_nil }
+        end
+
+        context 'when graphql_rails model is provided' do
+          let(:type) do
+            input_subtype = subtype
+
+            Class.new do
+              include GraphqlRails::Model
+
+              graphql.name 'Dummy'
+
+              graphql.input(input_subtype) do |c|
+                c.attribute(:name)
+              end
+            end
+          end
+
+          it 'returns original type' do
+            expect(graphql_model).to be(type)
+          end
+        end
+
+        context 'when standard type is provided' do
+          it { is_expected.to be_nil }
+        end
+      end
+
+      describe '#graphql_type_object' do
+        subject(:graphql_type_object) { parser.graphql_type_object }
+
+        context 'when custom type is GraphQL::Schema::Scalar expressed as string' do
+          let(:type) { '::GraphQL::Types::ISO8601Date!' }
+
+          it 'returns raw GraphQL::Schema::Scalar', :aggregate_failures do
+            expect(graphql_type_object).to eq ::GraphQL::Types::ISO8601Date
+          end
+        end
+
+        context 'when custom type is GraphQL::Schema::Object expressed as string' do
+          let(:type) { 'SomeImage' }
+          let(:type_class) do
+            Class.new(GraphQL::Schema::Object) do
+              graphql_name "SomeImage#{SecureRandom.hex}"
+            end
+          end
+
+          before do
+            Object.const_set('SomeImage', type_class)
+          end
+
+          it 'returns original GraphQL::Schema::Object' do
+            expect(graphql_type_object).to eq(type_class)
+          end
+        end
+
+        context 'when raw graphql scalar type is provided' do
+          let(:type) { GraphQL::Types::Int }
+
+          it 'returns given scalar type' do
+            expect(graphql_type_object).to eq(type)
+          end
+        end
+
+        context 'when graphql_rails model is provided' do
+          let(:type) do
+            input_subtype = subtype
+
+            Class.new do
+              include GraphqlRails::Model
+
+              graphql.name 'Dummy'
+
+              graphql.input(input_subtype) do |c|
+                c.name('DummyInput')
+                c.attribute(:name)
+              end
+            end
+          end
+
+          it 'returns model graphql type' do
+            expect(graphql_type_object).to be(type.graphql.graphql_type)
+          end
+        end
+
+        context 'when standard type is provided' do
+          it { is_expected.to be_nil }
+        end
+      end
+
+      describe '#input_type_arg' do
+        subject(:input_type_arg) { parser.input_type_arg }
+
+        context 'when graphql type is provided' do
+          let(:type) { GraphQL::INT_TYPE }
+
+          it 'returns original graphql type' do
+            expect(input_type_arg).to eq type
+          end
+        end
+
+        context 'when model type is provided' do
+          let(:type) { 'SomeImage' }
+
+          let(:type_class) do
+            Class.new do
+              include GraphqlRails::Model
+
+              graphql.name("SomeImage#{SecureRandom.hex}")
+              graphql.input do |c|
+                c.attribute(:url)
+              end
+            end
+          end
+
+          before do
+            stub_const('SomeImage', type_class)
+          end
+
+          it 'returns graphql type defined on that model' do
+            expect(input_type_arg.inspect).to eq 'GraphQL::Schema::InputObject(SomeImageInput)'
+          end
+        end
+
+        context 'when attribute is required' do
+          it 'returns raw type' do
+            expect(input_type_arg).to eq GraphQL::Types::String
+          end
+        end
+
+        context 'when attribute is optional' do
+          let(:type) { 'String' }
+
+          it 'includes graphql string type' do
+            expect(input_type_arg).to eq GraphQL::Types::String
+          end
+        end
+
+        context 'when attribute is integer' do
+          let(:type) { 'Int' }
+
+          it 'returns graphql integer type' do
+            expect(input_type_arg).to eq GraphQL::Types::Int
+          end
+        end
+
+        context 'when attribute is ID' do
+          let(:type) { 'ID' }
+
+          it { is_expected.to be GraphQL::Types::ID }
+        end
+
+        context 'when attribute is boolean' do
+          let(:type) { 'bool' }
+
+          it { is_expected.to be GraphQL::Types::Boolean }
+        end
+
+        context 'when attribute is float type' do
+          let(:type) { 'float' }
+
+          it { is_expected.to be GraphQL::Types::Float }
+        end
+
+        context 'when attribute is not supported' do
+          let(:type) { 'unknown' }
+
+          it 'raises error' do
+            expect { input_type_arg }.to raise_error(TypeParseable::UnknownTypeError)
+          end
+        end
+
+        context 'when attribute is array' do
+          let(:type) { '[Int!]!' }
+
+          context 'when array is required' do
+            let(:type) { '[Int]!' }
+
+            it 'returns array with "null: true" flag' do
+              expect(input_type_arg).to eq [GraphQL::Types::Int, { null: true }]
+            end
+          end
+
+          context 'when inner type of array is required' do
+            let(:type) { '[Int!]' }
+
+            it 'returns array without "null" flag' do
+              expect(input_type_arg).to eq [GraphQL::Types::Int]
+            end
+          end
+
+          context 'when array and its inner type is required' do
+            it 'returns array without "null" flag' do
+              expect(input_type_arg).to eq [GraphQL::Types::Int]
+            end
+          end
+
+          context 'when array and its inner type are optional' do
+            let(:type) { '[Int]' }
+
+            it 'returns array with "null: true" flag' do
+              expect(input_type_arg).to eq [GraphQL::Types::Int, { null: true }]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_rails/attributes/type_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/type_parser_spec.rb
@@ -45,6 +45,61 @@ module GraphqlRails
         end
       end
 
+      describe '#graphql_type_object' do
+        subject(:graphql_type_object) { parser.graphql_type_object }
+
+        context 'when custom type is GraphQL::Schema::Scalar expressed as string' do
+          let(:type) { '::GraphQL::Types::ISO8601Date!' }
+
+          it 'returns raw GraphQL::Schema::Scalar', :aggregate_failures do
+            expect(graphql_type_object).to eq ::GraphQL::Types::ISO8601Date
+          end
+        end
+
+        context 'when custom type is GraphQL::Schema::Object expressed as string' do
+          let(:type) { 'SomeImage' }
+          let(:type_class) do
+            Class.new(GraphQL::Schema::Object) do
+              graphql_name "SomeImage#{SecureRandom.hex}"
+            end
+          end
+
+          before do
+            Object.const_set('SomeImage', type_class)
+          end
+
+          it 'returns original GraphQL::Schema::Object' do
+            expect(graphql_type_object).to eq(type_class)
+          end
+        end
+
+        context 'when raw graphql scalar type is provided' do
+          let(:type) { GraphQL::Types::Int }
+
+          it 'returns given scalar type' do
+            expect(graphql_type_object).to eq(type)
+          end
+        end
+
+        context 'when graphql_rails model is provided' do
+          let(:type) do
+            Class.new do
+              include GraphqlRails::Model
+              graphql.attribute(:name)
+              graphql.name('Dummy')
+            end
+          end
+
+          it 'returns model graphql type' do
+            expect(graphql_type_object).to be(type.graphql.graphql_type)
+          end
+        end
+
+        context 'when standard type is provided' do
+          it { is_expected.to be_nil }
+        end
+      end
+
       describe '#type_arg' do
         subject(:type_arg) { parser.type_arg }
 

--- a/spec/lib/graphql_rails/model/find_or_build_graphql_type_spec.rb
+++ b/spec/lib/graphql_rails/model/find_or_build_graphql_type_spec.rb
@@ -82,6 +82,35 @@ module GraphqlRails
           end
         end
 
+        context 'when attribute is dynamically defined' do
+          let(:dummy_model_class) do
+            graphql_name = name
+            graphql_description = description
+
+            Class.new do
+              include Model
+
+              graphql do |c|
+                c.name graphql_name
+                c.description graphql_description
+                c.attribute(:date).type('::GraphQL::Types::ISO8601Date!')
+              end
+            end
+          end
+
+          it 'builds correct type' do
+            expect(call.to_type_signature).to eq name
+          end
+
+          it 'builds type with correct fields' do
+            expect(call.fields.keys).to match_array(%w[date])
+          end
+
+          it 'builds type without arguments' do
+            expect(call.fields['date'].arguments).to be_empty
+          end
+        end
+
         context 'when force redefine is required' do
           let(:force_define_attributes) { true }
           let(:dummy_model_class) do


### PR DESCRIPTION
This improvement allows defining graphql-ruby types dynamically using string:

before this change:
```ruby
class User
  include GraphqlRails::Model
  graphql.attribute(:required_list_of_dates)
         .type(::GraphQL::Types::ISO8601Date.to_non_null_type.to_list_type.to_non_null_type)
end
```

after change:
```ruby
class User
  include GraphqlRails::Model
  graphql.attribute(:required_list_of_dates)
         .type('[::GraphQL::Types::ISO8601Date!]!')
end
```
