### PR TITLE
Add more methods to relation decorator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ require: rubocop-rspec
 RSpec/NestedGroups:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 Layout/LineLength:
   Enabled: true
   Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added: decorated relations now can be called using "find", "empty?" and "find_by" methods
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.0.0](2021-12-03)

--- a/lib/graphql_rails/decorator/relation_decorator.rb
+++ b/lib/graphql_rails/decorator/relation_decorator.rb
@@ -5,7 +5,7 @@ module GraphqlRails
     # wrapps active record relation and returns decorated object instead
     class RelationDecorator
       delegate :map, :each, to: :to_a
-      delegate :limit_value, :offset_value, :count, :size, to: :relation
+      delegate :limit_value, :offset_value, :count, :size, :empty?, to: :relation
 
       def self.decorates?(object)
         (defined?(ActiveRecord) && object.is_a?(ActiveRecord::Relation)) ||
@@ -24,7 +24,7 @@ module GraphqlRails
         end
       end
 
-      %i[first second last].each do |method_name|
+      %i[first second last find find_by].each do |method_name|
         define_method method_name do |*args, &block|
           decoratable_object_method(method_name, *args, &block)
         end

--- a/spec/lib/graphql_rails/decorator/relation_decorator_spec.rb
+++ b/spec/lib/graphql_rails/decorator/relation_decorator_spec.rb
@@ -68,7 +68,7 @@ module GraphqlRails
       end
 
       describe '#find_by' do
-        subject(:find_by) { relation_decorator.find_by(1) }
+        subject(:find_by) { relation_decorator.find_by(id: 1) }
 
         it_behaves_like 'single decorated relation result', :find_by
       end

--- a/spec/lib/graphql_rails/decorator/relation_decorator_spec.rb
+++ b/spec/lib/graphql_rails/decorator/relation_decorator_spec.rb
@@ -14,6 +14,20 @@ module GraphqlRails
         )
       end
 
+      shared_examples 'single decorated relation result' do |method_name|
+        it 'returns instance of decorator' do
+          expect(subject).to be_a(decorator)
+        end
+
+        context 'when relation returns no record' do
+          before do
+            allow(relation).to receive(method_name).and_return(nil)
+          end
+
+          it { is_expected.to be nil }
+        end
+      end
+
       let(:decorator) do
         Class.new(SimpleDelegator) do
           attr_reader :args
@@ -32,6 +46,10 @@ module GraphqlRails
       let(:relation) do
         instance_double(
           ActiveRecord::Relation,
+          find: record,
+          second: record,
+          last: record,
+          find_by: record,
           first: record,
           to_a: [record, record2],
           where: inner_relation
@@ -43,22 +61,36 @@ module GraphqlRails
       let(:record) { OpenStruct.new(name: 'John') }
       let(:record2) { OpenStruct.new(name: 'Jack') }
 
+      describe '#find' do
+        subject(:find) { relation_decorator.find(1) }
+
+        it_behaves_like 'single decorated relation result', :find
+      end
+
+      describe '#find_by' do
+        subject(:find_by) { relation_decorator.find_by(1) }
+
+        it_behaves_like 'single decorated relation result', :find_by
+      end
+
+      describe '#second' do
+        subject(:second) { relation_decorator.second }
+
+        it_behaves_like 'single decorated relation result', :second
+      end
+
+      describe '#last' do
+        subject(:last) { relation_decorator.last }
+
+        it_behaves_like 'single decorated relation result', :last
+      end
+
       describe '#first' do
         subject(:first) { relation_decorator.first }
 
-        it 'returns instance of docorator' do
-          expect(first).to be_a(decorator)
-        end
+        it_behaves_like 'single decorated relation result', :first
 
-        context 'when relation returns no record' do
-          before do
-            allow(relation).to receive(:first).and_return(nil)
-          end
-
-          it { is_expected.to be nil }
-        end
-
-        context 'when first is called with items count' do
+        context 'when `first` is called with items count' do
           subject(:first) { relation_decorator.first(2) }
 
           before do


### PR DESCRIPTION
Currently decorated relation misses some methods quite often used with ActiveRecord relations. This PR adds additional methods:
```ruby
SomeDecorator.decorate(relation).find(1) # returns SomeDecorator instance
SomeDecorator.decorate(relation).find_by(1) # returns SomeDecorator instance or nil
SomeDecorator.decorate(relation).empty? # delegates to relation#empty?
```

### Changes with `empty?`

**before**

```ruby
# in graphql controller specs:
it 'returns empty list' do
  expect(request.result.to_a).to be_empty
end
```

**after**

```ruby
# in graphql controller specs:
it 'returns empty list' do
  expect(request.result).to be_empty
end
```

### Changes with find / find_by

**before**
since there is no `find_by` support, we need to hack using `where(id: 1).first`
and there is no easy way for hacking `find` :(
```ruby
SomeDecorator.decorate(relation).find(1) # raises no method error
SomeDecorator.decorate(relation).find_by(id: 1) # raises no method error
```

**after**

```ruby
SomeDecorator.decorate(relation).find(1) # returns SomeDecorator instance
SomeDecorator.decorate(relation).find_by(1) # returns SomeDecorator instance or nil
```
