### PR TITLE
Allow to define graphql-ruby enum classes as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added: decorated relations now can be called using "find", "empty?" and "find_by" methods
+* Fixed: allow to define graphql-ruby enum classes as strings.
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.0.0](2021-12-03)

--- a/lib/graphql_rails/attributes/type_parseable.rb
+++ b/lib/graphql_rails/attributes/type_parseable.rb
@@ -88,7 +88,7 @@ module GraphqlRails
       def graphql_type_object?(type_class)
         return false unless type_class.is_a?(Class)
 
-        type_class < GraphQL::Schema::Object || type_class < GraphQL::Schema::Scalar
+        type_class < GraphQL::Schema::Object || type_class < GraphQL::Schema::Scalar || type_class < GraphQL::Schema::Enum
       end
 
       def applicable_graphql_type?(type)

--- a/lib/graphql_rails/attributes/type_parseable.rb
+++ b/lib/graphql_rails/attributes/type_parseable.rb
@@ -43,6 +43,12 @@ module GraphqlRails
         GraphQL::InputObjectType
       ].freeze
 
+      PARSEABLE_RAW_GRAPHQL_TYPES = [
+        GraphQL::Schema::Object,
+        GraphQL::Schema::Scalar,
+        GraphQL::Schema::Enum
+      ].freeze
+
       RAW_GRAPHQL_TYPES = (WRAPPER_TYPES + GRAPHQL_BASE_TYPES).freeze
 
       def unwrapped_scalar_type
@@ -88,7 +94,7 @@ module GraphqlRails
       def graphql_type_object?(type_class)
         return false unless type_class.is_a?(Class)
 
-        type_class < GraphQL::Schema::Object || type_class < GraphQL::Schema::Scalar || type_class < GraphQL::Schema::Enum
+        PARSEABLE_RAW_GRAPHQL_TYPES.any? { |parent_type| type_class < parent_type }
       end
 
       def applicable_graphql_type?(type)

--- a/spec/lib/graphql_rails/attributes/type_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/type_parser_spec.rb
@@ -56,7 +56,25 @@ module GraphqlRails
           end
         end
 
-        context 'when custom type is GraphQL::Schema::Object expressed as string' do
+        context 'when enum class is expressed as string' do
+          let(:type) { 'SomeDummyEnum' }
+          let(:type_class) do
+            Class.new(GraphQL::Schema::Enum) do
+              graphql_name "SomeDummyEnum#{SecureRandom.hex}"
+              value 'OK', value: :ok
+            end
+          end
+
+          before do
+            Object.const_set('SomeDummyEnum', type_class)
+          end
+
+          it 'returns enum class', :aggregate_failures do
+            expect(graphql_type_object).to eq type_class
+          end
+        end
+
+        context 'when child class of GraphQL::Schema::Object expressed as string' do
           let(:type) { 'SomeImage' }
           let(:type_class) do
             Class.new(GraphQL::Schema::Object) do


### PR DESCRIPTION
Currently, we have a bug when referencing attribute type as a string and that type is defined as graphql-ruby enum such as this:

```ruby
class ColorsEnum < BaseEnum
  value 'RED', value: :red
  value 'BLUE', value: :blue
end
```

before:
```ruby
class SomeModel
  graphql.attribute(:colors).type('[ColorsEnum!]!') # raises GraphqlRails::Attributes::TypeParseable::UnknownTypeError: Type "[ColorsEnum!]!" is not supported...
end
```

after:
```ruby
class SomeModel
  graphql.attribute(:colors).type('[ColorsEnum!]!') # all good!
end
```