### PR TITLE
Add aliases for common graphql-graphql types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added: decorated relations now can be called using "find", "empty?" and "find_by" methods
 * Fixed: allow to define graphql-ruby enum classes as strings.
+* Changed: `date` type is now alias for `GraphQL::Types::ISO8601Date`, also added aliases for other common graphql-graphql types.
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.0.0](2021-12-03)

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -31,14 +31,7 @@ Some types can be determined by attribute name, so you can skip this attribute:
 * attributes which ends with `?` has `Boolean!` type
 * all other attributes without type are considered to be `String`
 
-available types are:
-
-* ID: `'id'`
-* String: `'string'`, `'str'`, `'text'`
-* Boolean: `'bool'`, `'boolean'`
-* Float: `'float'`, `'double'`, `'decimal'`
-
-usage example:
+Usage example:
 
 ```ruby
 class User
@@ -50,6 +43,34 @@ class User
     c.attribute :admin? # Boolean! type
     c.attribute :level, type: 'integer'
     c.attribute :money, type: 'float'
+  end
+end
+```
+
+You can also use some build in aliases for types, such as:
+
+* `'id'` is alias for `GraphQL::Types::ID`
+* `'integer'`, `'int'` are aliases for `GraphQL::Types::Int`
+* `'bigint'`, `'big_int'` are aliases for `GraphQL::Types::BigInt`
+* 'float', 'double', 'decimal' are aliases for `GraphQL::Types::Float`
+* `'bool'`, `'boolean'` are aliases for GraphQL::Types::Boolean
+* String: `'string'`, `'str'`, `'text'`
+* 'date' is alias for `GraphQL::Types::ISO8601Date`
+* 'time', 'datetime', 'date_time' are aliases for `GraphQL::Types::ISO8601DateTime`
+* 'json' is alias for `GraphQL::Types::JSON`
+
+Usage example:
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    c.attribute(:about_me).type(:text)
+    c.attribute(:active).type('bool!')
+    c.attribute(:created_at).type(:datetime!)
+    c.attribute(:data).type(:json!)
+    c.attribute(:login_dates).type('[date!]!')
   end
 end
 ```

--- a/lib/graphql_rails/attributes/type_parseable.rb
+++ b/lib/graphql_rails/attributes/type_parseable.rb
@@ -16,18 +16,27 @@ module GraphqlRails
         'int' => GraphQL::Types::Int,
         'integer' => GraphQL::Types::Int,
 
-        'string' => GraphQL::Types::String,
-        'str' => GraphQL::Types::String,
-        'text' => GraphQL::Types::String,
-        'time' => GraphQL::Types::String,
-        'date' => GraphQL::Types::String,
+        'big_int' => GraphQL::Types::BigInt,
+        'bigint' => GraphQL::Types::BigInt,
+
+        'float' => GraphQL::Types::Float,
+        'double' => GraphQL::Types::Float,
+        'decimal' => GraphQL::Types::Float,
 
         'bool' => GraphQL::Types::Boolean,
         'boolean' => GraphQL::Types::Boolean,
 
-        'float' => GraphQL::Types::Float,
-        'double' => GraphQL::Types::Float,
-        'decimal' => GraphQL::Types::Float
+        'string' => GraphQL::Types::String,
+        'str' => GraphQL::Types::String,
+        'text' => GraphQL::Types::String,
+
+        'date' => GraphQL::Types::ISO8601Date,
+
+        'time' => GraphQL::Types::ISO8601DateTime,
+        'datetime' => GraphQL::Types::ISO8601DateTime,
+        'date_time' => GraphQL::Types::ISO8601DateTime,
+
+        'json' => GraphQL::Types::JSON
       }.freeze
 
       WRAPPER_TYPES = [
@@ -52,7 +61,7 @@ module GraphqlRails
       RAW_GRAPHQL_TYPES = (WRAPPER_TYPES + GRAPHQL_BASE_TYPES).freeze
 
       def unwrapped_scalar_type
-        TYPE_MAPPING[nullable_inner_name.downcase.downcase]
+        TYPE_MAPPING[nullable_inner_name.downcase]
       end
 
       def raw_graphql_type?

--- a/spec/lib/graphql_rails/attributes/type_parseable_spec.rb
+++ b/spec/lib/graphql_rails/attributes/type_parseable_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module GraphqlRails
+  module Attributes
+    RSpec.describe TypeParseable do
+      subject(:parser) { parser_class.new(unparsed_type: unparsed_type) }
+
+      let(:parser_class) do
+        Class.new do
+          include GraphqlRails::Attributes::TypeParseable
+
+          attr_reader :unparsed_type
+
+          def initialize(unparsed_type:)
+            @unparsed_type = unparsed_type
+          end
+        end
+      end
+
+      let(:unparsed_type) { 'int!' }
+
+      describe '#unwrapped_scalar_type' do
+        subject(:unwrapped_scalar_type) { parser.unwrapped_scalar_type }
+
+        context 'when "id" type is given' do
+          let(:unparsed_type) { 'id!' }
+
+          it { is_expected.to eq GraphQL::Types::ID }
+        end
+
+        context 'when "int" type is given' do
+          let(:unparsed_type) { 'int!' }
+
+          it { is_expected.to eq GraphQL::Types::Int }
+        end
+
+        context 'when "integer" type is given' do
+          let(:unparsed_type) { 'integer!' }
+
+          it { is_expected.to eq GraphQL::Types::Int }
+        end
+
+        context 'when "big_int" type is given' do
+          let(:unparsed_type) { 'big_int!' }
+
+          it { is_expected.to eq GraphQL::Types::BigInt }
+        end
+
+        context 'when "bigint" type is given' do
+          let(:unparsed_type) { 'bigint!' }
+
+          it { is_expected.to eq GraphQL::Types::BigInt }
+        end
+
+        context 'when "float" type is given' do
+          let(:unparsed_type) { 'float!' }
+
+          it { is_expected.to eq GraphQL::Types::Float }
+        end
+
+        context 'when "double" type is given' do
+          let(:unparsed_type) { 'double!' }
+
+          it { is_expected.to eq GraphQL::Types::Float }
+        end
+
+        context 'when "decimal" type is given' do
+          let(:unparsed_type) { 'decimal!' }
+
+          it { is_expected.to eq GraphQL::Types::Float }
+        end
+
+        context 'when "bool" type is given' do
+          let(:unparsed_type) { 'bool!' }
+
+          it { is_expected.to eq GraphQL::Types::Boolean }
+        end
+
+        context 'when "boolean" type is given' do
+          let(:unparsed_type) { 'boolean!' }
+
+          it { is_expected.to eq GraphQL::Types::Boolean }
+        end
+
+        context 'when "string" type is given' do
+          let(:unparsed_type) { 'string!' }
+
+          it { is_expected.to eq GraphQL::Types::String }
+        end
+
+        context 'when "str" type is given' do
+          let(:unparsed_type) { 'str!' }
+
+          it { is_expected.to eq GraphQL::Types::String }
+        end
+
+        context 'when "text" type is given' do
+          let(:unparsed_type) { 'text!' }
+
+          it { is_expected.to eq GraphQL::Types::String }
+        end
+
+        context 'when "date" type is given' do
+          let(:unparsed_type) { 'date' }
+
+          it { is_expected.to eq GraphQL::Types::ISO8601Date }
+        end
+
+        context 'when "time" type is given' do
+          let(:unparsed_type) { 'time!' }
+
+          it { is_expected.to eq GraphQL::Types::ISO8601DateTime }
+        end
+
+        context 'when "datetime" type is given' do
+          let(:unparsed_type) { 'datetime!' }
+
+          it { is_expected.to eq GraphQL::Types::ISO8601DateTime }
+        end
+
+        context 'when "date_time" type is given' do
+          let(:unparsed_type) { '[DateTime!]' }
+
+          it { is_expected.to eq GraphQL::Types::ISO8601DateTime }
+        end
+
+        context 'when "json" type is given' do
+          let(:unparsed_type) { 'json!' }
+
+          it { is_expected.to eq GraphQL::Types::JSON }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds aliases for some frequently used not-so-standard graphql types

```ruby
class Foo
  include GraphqlRails::Model
  
  graphql do |c|
    c.attribute(:blocked_from).type(:date)
    c.attribute(:data).type(:json)
    c.attribute(:updated_at).type(:datetime)
  end
end
```

Keep in mind that this PR introduces breaking change. Previously `date` was an alias for `String` and now it's changed to `GraphQL::Types::ISO8601Date!`. Since this was not documented, I assume that it's quite safe to change it.

Solves https://github.com/samesystem/graphql_rails/issues/92