### PR TITLE
Add groups to models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added: decorated relations now can be called using "find", "empty?" and "find_by" methods
 * Fixed: allow to define graphql-ruby enum classes as strings.
+* Added: add "groups" to attributes.
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.0.0](2021-12-03)

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -110,6 +110,45 @@ class User
 end
 ```
 
+### attribute.groups
+
+Groups are handy feature when you want to have multiple schemas. For example, you want to have public graphql endpoint and internal graphql endpoint where each group has some unique nodes. If attribute has `groups` set, then this attribute will be visible only in appropriate group schemas.
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    # visible in all schemas (default):
+    c.attribute(:email)
+
+    # visible in "internal" and "beta" schemas only:
+    c.attribute(:admin_id).groups(%i[internal beta])
+
+    # visible in "external" schema only:
+    c.attribute(:nickname).groups(%i[external])
+  end
+end
+```
+
+### attribute.group
+
+Alias for Attribute#groups.
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    # visible in all schemas (default):
+    c.attribute(:email)
+
+    # visible in "external" schema only:
+    c.attribute(:nickname).group(:external)
+  end
+end
+```
+
 ### attribute.options
 
 Allows passing options to attribute definition. Available options:

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -40,7 +40,8 @@ module GraphqlRails
         {
           method: property.to_sym,
           null: optional?,
-          camelize: camelize?
+          camelize: camelize?,
+          groups: groups
         }
       end
 

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -20,6 +20,18 @@ module GraphqlRails
         chainable_option :type
       end
 
+      def groups(new_groups = ChainableOptions::NOT_SET)
+        @groups ||= []
+        return @groups if new_groups == ChainableOptions::NOT_SET
+
+        @groups = Array(new_groups).map(&:to_s)
+        self
+      end
+
+      def group(*args)
+        groups(*args)
+      end
+
       def required(new_value = true) # rubocop:disable Style/OptionalBooleanParameter
         @required = new_value
         self

--- a/lib/graphql_rails/attributes/input_attribute.rb
+++ b/lib/graphql_rails/attributes/input_attribute.rb
@@ -25,7 +25,7 @@ module GraphqlRails
       end
 
       def input_argument_options
-        { required: required?, description: description, camelize: false }
+        { required: required?, description: description, camelize: false, groups: groups }
       end
 
       def paginated?

--- a/lib/graphql_rails/controller/build_controller_action_resolver/controller_action_resolver.rb
+++ b/lib/graphql_rails/controller/build_controller_action_resolver/controller_action_resolver.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'graphql_rails/controller/request'
+require 'graphql_rails/types/argument_type'
 
 module GraphqlRails
   class Controller
@@ -8,6 +9,8 @@ module GraphqlRails
       # Resolver which includes controller specific methods.
       # Used to simplify resolver build for each controller action
       class ControllerActionResolver < GraphQL::Schema::Resolver
+        argument_class(GraphqlRails::Types::ArgumentType)
+
         def self.controller(controller_class = nil)
           @controller = controller_class if controller_class
           @controller

--- a/lib/graphql_rails/model/build_graphql_input_type.rb
+++ b/lib/graphql_rails/model/build_graphql_input_type.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+require 'graphql_rails/types/argument_type'
+require 'graphql_rails/concerns/service'
+
 module GraphqlRails
   module Model
     # stores information about model specific config, like attributes and types
     class BuildGraphqlInputType
-      require 'graphql_rails/concerns/service'
-
       include ::GraphqlRails::Service
 
       def initialize(name:, description: nil, attributes:)
@@ -20,6 +21,7 @@ module GraphqlRails
         type_attributes = attributes
 
         Class.new(GraphQL::Schema::InputObject) do
+          argument_class(GraphqlRails::Types::ArgumentType)
           graphql_name(type_name)
           description(type_description)
 

--- a/lib/graphql_rails/model/find_or_build_graphql_type_class.rb
+++ b/lib/graphql_rails/model/find_or_build_graphql_type_class.rb
@@ -5,6 +5,7 @@ module GraphqlRails
     # Initializes class to define graphql type and fields.
     class FindOrBuildGraphqlTypeClass
       require 'graphql_rails/concerns/service'
+      require 'graphql_rails/types/object_type'
 
       include ::GraphqlRails::Service
 
@@ -32,7 +33,7 @@ module GraphqlRails
         graphql_type_name = name
         graphql_type_description = description
 
-        graphql_type_klass = Class.new(GraphQL::Schema::Object) do
+        graphql_type_klass = Class.new(GraphqlRails::Types::ObjectType) do
           graphql_name(graphql_type_name)
           description(graphql_type_description)
         end

--- a/lib/graphql_rails/query_runner.rb
+++ b/lib/graphql_rails/query_runner.rb
@@ -8,12 +8,13 @@ module GraphqlRails
 
     include ::GraphqlRails::Service
 
-    def initialize(group: nil, params:, schema: nil, router: nil, **schema_options)
+    def initialize(params:, context: {}, schema: nil, router: nil, group: nil, **schema_options) # rubocop:disable Metrics/ParameterLists
       @group = group
       @graphql_schema = schema
       @params = params
-      @schema_options = schema_options
       @router = router
+      @initial_context = context
+      @schema_options = schema_options
     end
 
     def call
@@ -21,13 +22,18 @@ module GraphqlRails
         params[:query],
         variables: variables,
         operation_name: params[:operationName],
+        context: context,
         **schema_options
       )
     end
 
     private
 
-    attr_reader :schema_options, :params, :group
+    attr_reader :schema_options, :params, :group, :initial_context
+
+    def context
+      initial_context.merge(graphql_group: group)
+    end
 
     def variables
       ensure_hash(params[:variables])

--- a/lib/graphql_rails/tasks/dump_graphql_schema.rb
+++ b/lib/graphql_rails/tasks/dump_graphql_schema.rb
@@ -18,12 +18,17 @@ module GraphqlRails
     end
 
     def call
-      File.write(schema_path, schema.to_definition)
+      File.write(schema_path, schema_dump)
     end
 
     private
 
     attr_reader :router, :group
+
+    def schema_dump
+      context = { graphql_group: group }
+      schema.to_definition(context: context)
+    end
 
     def schema
       @schema ||= router.graphql_schema(group.presence)

--- a/lib/graphql_rails/types/argument_type.rb
+++ b/lib/graphql_rails/types/argument_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'graphql_rails/types/hidable_by_group'
+
+module GraphqlRails
+  module Types
+    # Base argument type for all GraphqlRails inputs
+    class ArgumentType < GraphQL::Schema::Argument
+      include GraphqlRails::Types::HidableByGroup
+    end
+  end
+end

--- a/lib/graphql_rails/types/field_type.rb
+++ b/lib/graphql_rails/types/field_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'graphql_rails/types/argument_type'
+require 'graphql_rails/types/hidable_by_group'
+
+module GraphqlRails
+  module Types
+    # Base field for all GraphqlRails model fields
+    class FieldType < GraphQL::Schema::Field
+      include GraphqlRails::Types::HidableByGroup
+      argument_class(GraphqlRails::Types::ArgumentType)
+    end
+  end
+end

--- a/lib/graphql_rails/types/hidable_by_group.rb
+++ b/lib/graphql_rails/types/hidable_by_group.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'graphql_rails/types/argument_type'
+
+module GraphqlRails
+  module Types
+    # Add visibility option based on groups
+    module HidableByGroup
+      def initialize(*args, groups: [], **kwargs, &block)
+        super(*args, **kwargs, &block)
+
+        @groups = groups.map(&:to_s)
+      end
+
+      def visible?(context)
+        super && visible_in_context_group?(context)
+      end
+
+      private
+
+      def groups
+        @groups
+      end
+
+      def visible_in_context_group?(context)
+        group = context[:graphql_group] || context['graphql_group']
+
+        group.nil? || groups.empty? || groups.include?(group.to_s)
+      end
+    end
+  end
+end

--- a/lib/graphql_rails/types/object_type.rb
+++ b/lib/graphql_rails/types/object_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'graphql_rails/types/field_type'
+
+module GraphqlRails
+  module Types
+    # Base graphql type class for all GraphqlRails models
+    class ObjectType < GraphQL::Schema::Object
+      field_class(GraphqlRails::Types::FieldType)
+    end
+  end
+end

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -211,6 +211,22 @@ module GraphqlRails
             end
           end
         end
+
+        context 'when attribute does not belong to any groups' do
+          it 'builds field with empty groups' do
+            expect(field_options).to include(groups: [])
+          end
+        end
+
+        context 'when attribute belongs to a group' do
+          before do
+            attribute.group(:some_group)
+          end
+
+          it 'builds field with a given group' do
+            expect(field_options).to include(groups: %w[some_group])
+          end
+        end
       end
     end
   end

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -87,7 +87,7 @@ module GraphqlRails
           end
         end
 
-        context 'when type is a raw grapqhl input class' do
+        context 'when type is a raw graphql input class' do
           let(:type) do
             GraphQL::InputObjectType.define do
               name 'DummyInput'
@@ -185,6 +185,22 @@ module GraphqlRails
             it 'takes in to account input format options' do
               expect(input_argument_name).to eq 'full_name'
             end
+          end
+        end
+
+        context 'when input does not belong to any groups' do
+          it 'builds field with empty groups' do
+            expect(input_argument_options).to include(groups: [])
+          end
+        end
+
+        context 'when input belongs to a group' do
+          before do
+            attribute.group(:some_group)
+          end
+
+          it 'builds field with a given group' do
+            expect(input_argument_options).to include(groups: %w[some_group])
           end
         end
       end

--- a/spec/lib/graphql_rails/tasks/dump_graphql_schema_spec.rb
+++ b/spec/lib/graphql_rails/tasks/dump_graphql_schema_spec.rb
@@ -33,6 +33,19 @@ module GraphqlRails
 
       context 'when group name is given' do
         let(:group) { 'custom' }
+        let(:schema_double) { double('Schema') } # rubocop:disable RSpec/VerifiedDoubles
+        let(:graphql_router) { instance_double('GraphqlRails::Router', graphql_schema: schema_double) }
+
+        before do
+          allow(graphql_router).to receive(:graphql_schema).and_return(schema_double)
+          allow(schema_double).to receive(:to_definition).and_return('')
+        end
+
+        it 'dumps schema with group context', :aggregate_failures do
+          call
+          expect(graphql_router).to have_received(:graphql_schema).with('custom')
+          expect(schema_double).to have_received(:to_definition).with(context: { graphql_group: 'custom' })
+        end
 
         it 'writes router definition to group schema file' do
           call


### PR DESCRIPTION
This feature allows limiting field visibility only for certain groups. Works similar as `groups` in router, but on attribute level. Works with input attributes (arguments) too.

Solves https://github.com/samesystem/graphql_rails/issues/119