### PR TITLE
Allow any graphql member object to be used in stringified form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added: support for subscription type
+* Fixed: correctly detect all graphql-ruby objects when using stringified types
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.1.0](2022-01-12)

--- a/lib/graphql_rails/attributes/type_parseable.rb
+++ b/lib/graphql_rails/attributes/type_parseable.rb
@@ -52,12 +52,6 @@ module GraphqlRails
         GraphQL::InputObjectType
       ].freeze
 
-      PARSEABLE_RAW_GRAPHQL_TYPES = [
-        GraphQL::Schema::Object,
-        GraphQL::Schema::Scalar,
-        GraphQL::Schema::Enum
-      ].freeze
-
       RAW_GRAPHQL_TYPES = (WRAPPER_TYPES + GRAPHQL_BASE_TYPES).freeze
 
       def unwrapped_scalar_type
@@ -103,7 +97,7 @@ module GraphqlRails
       def graphql_type_object?(type_class)
         return false unless type_class.is_a?(Class)
 
-        PARSEABLE_RAW_GRAPHQL_TYPES.any? { |parent_type| type_class < parent_type }
+        type_class < GraphQL::Schema::Member
       end
 
       def applicable_graphql_type?(type)

--- a/spec/lib/graphql_rails/attributes/type_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/type_parser_spec.rb
@@ -86,7 +86,25 @@ module GraphqlRails
             Object.const_set('SomeImage', type_class)
           end
 
-          it 'returns original GraphQL::Schema::Object' do
+          it 'returns original child class of  GraphQL::Schema::Object' do
+            expect(graphql_type_object).to eq(type_class)
+          end
+        end
+
+        context 'when child class of GraphQL::Schema::InputObject expressed as string' do
+          let(:type) { '[SomeImageInput!]!' }
+          let(:type_class) do
+            Class.new(GraphQL::Schema::InputObject) do
+              graphql_name "SomeImageInput#{SecureRandom.hex}"
+              argument :date, type: GraphQL::Types::ISO8601Date, required: true
+            end
+          end
+
+          before do
+            Object.const_set('SomeImageInput', type_class)
+          end
+
+          it 'returns original child class of GraphQL::Schema::InputObject' do
             expect(graphql_type_object).to eq(type_class)
           end
         end


### PR DESCRIPTION
Currently, it's impossible to set stringified type for graphql-ruby input type. This PR fixes that issue and prevents similar issues from happening in the future.

**before** 

```ruby
class User
  graphql.attribute(:data).type('Types::DataInputType!') # raises error
end
```

**after** 

```ruby
class User
  graphql.attribute(:data).type('Types::DataInputType!') # no error
end
```