### PR TITLE
Refs #229: Always define query type to allow introspection

### DIFF
--- a/lib/graphql_rails/router/schema_builder.rb
+++ b/lib/graphql_rails/router/schema_builder.rb
@@ -49,7 +49,7 @@ module GraphqlRails
           .uniq(&:name)
           .reverse
 
-        return if group_routes.empty?
+        return if group_routes.empty? && type_name != 'Query'
 
         build_type(type_name, group_routes)
       end

--- a/spec/lib/graphql_rails/router_spec.rb
+++ b/spec/lib/graphql_rails/router_spec.rb
@@ -118,11 +118,14 @@ module GraphqlRails
           end
         end
 
-        it 'returns schema without mutation type' do # rubocop:disable RSpec/ExampleLength
+        it 'returns schema with empty query type' do # rubocop:disable RSpec/ExampleLength
           expect(graphql_schema.to_definition).to eq(
             <<~GRAPHQL
               type Mutation {
                 customQuery: String!
+              }
+
+              type Query {
               }
 
               type Subscription {


### PR DESCRIPTION
Query type must always be defined to allow doing schema introspection. 