### PR TITLE
Add namespaces and scope prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 * Added support for Ruby 3.1.2, keyword arguments for decorators support included
-
-* Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
-
 * Added: error backtrace to SystemError
 * Fixed: skip "base" field name in validation error messages
+* Added: router namespaces and named scopes
+* Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.2.0](2022-01-25)
 

--- a/docs/components/routes.md
+++ b/docs/components/routes.md
@@ -89,16 +89,52 @@ end
 
 ### _module_ options
 
-currently `scope` method accepts single option: `module`. `module` allows to specify controller namespace. So you can use scoped controllers, like so:
+If you want to want to route everything to controllers, located at `controllers/admin/top_secret`, you can use scope with `module` param:
 
 ```ruby
-MyGraphqlSchema = GraphqlRails::Router.draw do
-  scope module: 'admin/top_secret' do
-    mutation :logIn, to: 'sessions#login' # this will trigger Admin::TopSecret::SessionsController
-  end
+scope module: 'admin/top_secret' do
+  mutation :logIn, to: 'sessions#login' # this will trigger Admin::TopSecret::SessionsController
+end
+```
 
+### Named scope
+
+If you want to nest some routes under some other node, you can use named scope:
+
+```ruby
+scope :admin do
   mutation :logIn, to: 'sessions#login' # this will trigger ::SessionsController
 end
+```
+
+This action will be accessible via:
+
+```graphql
+mutation {
+  admin {
+    logIn(email: 'john@example.com') { ... }
+  }
+}
+```
+
+## _namespace_
+
+You may wish to organize groups of controllers under a namespace. Most commonly, you might group a number of administrative controllers under an `Admin::` namespace, and place these controllers under the app/controllers/admin directory. You can route to such a group by using a namespace block:
+
+```ruby
+  namespace :admin do
+    resources :articles, only: :show
+  end
+```
+
+On GraphQL side, you can reach such route with the following query:
+
+```graphql
+query {
+  admin {
+    article(id: '123') { ... }
+  }
+}
 ```
 
 ## _group_

--- a/lib/graphql_rails/router/build_schema_action_type.rb
+++ b/lib/graphql_rails/router/build_schema_action_type.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module GraphqlRails
+  class Router
+    # Builds GraphQL type used in graphql schema
+    class BuildSchemaActionType
+      ROUTES_KEY = :__routes__
+
+      # @private
+      class SchemaActionType < GraphQL::Schema::Object
+        def self.inspect
+          "#{GraphQL::Schema::Object}(#{graphql_name})"
+        end
+
+        class << self
+          def fields_for_nested_routes(type_name_prefix:, scoped_routes:)
+            routes_by_scope = scoped_routes.dup
+            unscoped_routes = routes_by_scope.delete(ROUTES_KEY) || []
+
+            scoped_only_fields(type_name_prefix, routes_by_scope)
+            unscoped_routes.each { route_field(_1) }
+          end
+
+          private
+
+          def route_field(route)
+            field(*route.name, **route.field_options)
+          end
+
+          def scoped_only_fields(type_name_prefix, routes_by_scope)
+            routes_by_scope.each_pair do |scope_name, inner_scope_routes|
+              scope_field(scope_name, "#{type_name_prefix}#{scope_name.to_s.camelize}", inner_scope_routes)
+            end
+          end
+
+          def scope_field(scope_name, scope_type_name, scoped_routes)
+            scope_type = build_scope_type_class(
+              type_name: scope_type_name,
+              scoped_routes: scoped_routes
+            )
+
+            field(scope_name.to_s.camelize(:lower), scope_type, null: false)
+            define_method(scope_type_name.underscore) { self }
+          end
+
+          def build_scope_type_class(type_name:, scoped_routes:)
+            Class.new(SchemaActionType) do
+              graphql_name("#{type_name}Scope")
+
+              fields_for_nested_routes(
+                type_name_prefix: type_name,
+                scoped_routes: scoped_routes
+              )
+            end
+          end
+        end
+      end
+
+      def self.call(**kwargs)
+        new(**kwargs).call
+      end
+
+      def initialize(type_name:, routes:)
+        @type_name = type_name
+        @routes = routes
+      end
+
+      def call
+        type_name = self.type_name
+        scoped_routes = self.scoped_routes
+
+        Class.new(SchemaActionType) do
+          graphql_name(type_name)
+
+          fields_for_nested_routes(
+            type_name_prefix: type_name,
+            scoped_routes: scoped_routes
+          )
+        end
+      end
+
+      private
+
+      attr_reader :type_name, :routes
+
+      def scoped_routes
+        routes.each_with_object({}) do |route, result|
+          scope_names = route.scope_names.map { _1.to_s.camelize(:lower) }
+          path_to_routes = scope_names + [ROUTES_KEY]
+          deep_append(result, path_to_routes, route)
+        end
+      end
+
+      # adds array element to nested hash
+      # usage:
+      #   deep_hash =   { a: { b: [1] } }
+      #   deep_append(deep_hash, [:a, :b], 2)
+      #   deep_hash #=> { a: { b: [1, 2] } }
+      def deep_append(hash, keys, value)
+        deepest_hash = hash
+        *other_keys, last_key = keys
+
+        other_keys.each do |key|
+          deepest_hash[key] ||= {}
+          deepest_hash = deepest_hash[key]
+        end
+        deepest_hash[last_key] ||= []
+        deepest_hash[last_key] += [value]
+      end
+    end
+  end
+end

--- a/lib/graphql_rails/router/route.rb
+++ b/lib/graphql_rails/router/route.rb
@@ -6,15 +6,16 @@ module GraphqlRails
   class Router
     # Generic class for any type graphql action. Should not be used directly
     class Route
-      attr_reader :name, :module_name, :on, :relative_path, :groups
+      attr_reader :name, :module_name, :on, :relative_path, :groups, :scope_names
 
-      def initialize(name, to: '', on:, groups: nil, **options)
+      def initialize(name, on:, to: '', groups: nil, scope_names: [], **options) # rubocop:disable Metrics/ParameterLists
         @name = name.to_s.camelize(:lower)
         @module_name = options[:module].to_s
         @function = options[:function]
         @groups = groups
         @relative_path = to
         @on = on.to_sym
+        @scope_names = scope_names
       end
 
       def path

--- a/lib/graphql_rails/router/schema_builder.rb
+++ b/lib/graphql_rails/router/schema_builder.rb
@@ -5,6 +5,7 @@ module GraphqlRails
     # builds GraphQL::Schema based on previously defined grahiti data
     class SchemaBuilder
       require_relative './plain_cursor_encoder'
+      require_relative './build_schema_action_type'
 
       attr_reader :queries, :mutations, :subscriptions, :raw_actions
 
@@ -51,21 +52,7 @@ module GraphqlRails
 
         return if group_routes.empty? && type_name != 'Query'
 
-        build_type(type_name, group_routes)
-      end
-
-      def build_type(type_name, group_routes)
-        Class.new(GraphQL::Schema::Object) do
-          graphql_name(type_name)
-
-          group_routes.each do |route|
-            field(*route.name, **route.field_options)
-          end
-
-          def self.inspect
-            "#{GraphQL::Schema::Object}(#{graphql_name})"
-          end
-        end
+        BuildSchemaActionType.call(type_name: type_name, routes: group_routes)
       end
     end
   end

--- a/spec/lib/graphql_rails/router/build_schema_action_type_spec.rb
+++ b/spec/lib/graphql_rails/router/build_schema_action_type_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/dummy_app/dummy'
+
+module GraphqlRails
+  RSpec.describe Router::BuildSchemaActionType do
+    describe '.call' do
+      subject(:call) { described_class.call(type_name: type_name, routes: routes) }
+
+      let(:type_name) { 'Test' }
+      let(:routes) { router.routes }
+      let(:router) { Router.new }
+
+      context 'with no routes' do
+        it 'returns GraphQL type with no fields' do
+          expect(call.fields).to be_empty
+        end
+      end
+
+      context 'with top level route' do
+        before do
+          router.query(:user, to: 'dummy/users#show')
+        end
+
+        it 'returns GraphQL type with fields matching routes', :aggregate_failures do
+          expect(call.inspect).to eq('GraphQL::Schema::Object(Test)')
+          expect(call.fields.keys).to match_array(%w[user])
+        end
+      end
+
+      context 'with scoped and namespaced route' do
+        before do
+          router.namespace(:dummy) do
+            scope :users_area do
+              query(:user, to: 'users#show')
+            end
+          end
+        end
+
+        it 'returns GraphQL type with deep nested fields matching', :aggregate_failures do
+          expect(call.fields.keys).to match_array(%w[dummy])
+
+          dummy_namespace = call.fields['dummy'].type.unwrap
+          expect(dummy_namespace.fields.keys).to match_array(%w[usersArea])
+
+          users_area_scope = dummy_namespace.fields['usersArea'].type.unwrap
+          expect(users_area_scope.fields.keys).to match_array(%w[user])
+        end
+      end
+    end
+  end
+end

--- a/spec/support/dummy_app/controllers/dummy/users_controllers.rb
+++ b/spec/support/dummy_app/controllers/dummy/users_controllers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../../models/dummy/user'
+
+module Dummy
+  class UsersController < GraphqlRails::Controller
+    action(:show)
+      .permit(id: 'ID!')
+      .returns(::Dummy::User.to_s)
+
+    def show
+      User.new(name: 'John')
+    end
+  end
+end

--- a/spec/support/dummy_app/dummy.rb
+++ b/spec/support/dummy_app/dummy.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative 'controllers/dummy/users_controllers'
+
+module Dummy
+end

--- a/spec/support/dummy_app/models/dummy/user.rb
+++ b/spec/support/dummy_app/models/dummy/user.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Dummy
+  class User
+    include GraphqlRails::Model
+
+    graphql do |c|
+      c.name("DummyUser#{SecureRandom.hex}")
+
+      c.attribute :name
+    end
+
+    attr_reader :name
+
+    def initialize(name:)
+      @name = name
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two new router features: `namespace` and `scope`. It allows to nest actions (action can be deep nested too). Here is an example:

```ruby
query :user, to: 'users#show'  # triggers users_controller

scope :top_secret do
  query :user, to: 'top_secret_users#show'  # triggers top_secret_users_controller
end

namespace :admin do
  query :user, to: 'users#show' # triggers admin/users_controller
end
```

on graphql it can be accessed like this:

```graphql
query {
  user(id: '1') { ... } # triggers users_controller
  
  topSecret {
    user(id: '1') { ... } # triggers top_secret_users_controller
  }

  admin {
    user(id: '1') { ... }  # triggers admin/users_controller
  }
}
```

solves: https://github.com/samesystem/graphql_rails/issues/53