### PR TITLE
Add `hidden_in_groups` option for attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
+* Added: `hidden_in_groups` for attributes to be able to skip attribute from certain groups
 
 ## [2.3.0](2022-11-25)
 

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -185,6 +185,24 @@ class User
 end
 ```
 
+### attribute.hidden_in_groups
+
+Opposite for Attribute#groups. It hides attribute in given groups
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    # visible in all schemas (default):
+    c.attribute(:email)
+
+    # visible in all schemas except "external":
+    c.attribute(:nickname).hidden_in_groups(:external)
+  end
+end
+```
+
 ### attribute.options
 
 Allows passing options to attribute definition. Available options:

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -42,6 +42,7 @@ module GraphqlRails
           null: optional?,
           camelize: camelize?,
           groups: groups,
+          hidden_in_groups: hidden_in_groups,
           **deprecation_reason_params
         }
       end

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -32,6 +32,14 @@ module GraphqlRails
         groups(*args)
       end
 
+      def hidden_in_groups(new_groups = ChainableOptions::NOT_SET)
+        @hidden_in_groups ||= []
+        return @hidden_in_groups if new_groups == ChainableOptions::NOT_SET
+
+        @hidden_in_groups = Array(new_groups).map(&:to_s)
+        self
+      end
+
       def required(new_value = true) # rubocop:disable Style/OptionalBooleanParameter
         @required = new_value
         self

--- a/lib/graphql_rails/attributes/input_attribute.rb
+++ b/lib/graphql_rails/attributes/input_attribute.rb
@@ -31,6 +31,7 @@ module GraphqlRails
           description: description,
           camelize: false,
           groups: groups,
+          hidden_in_groups: hidden_in_groups,
           **default_value_option,
           **deprecation_reason_params
         }

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -235,6 +235,16 @@ module GraphqlRails
           end
         end
 
+        context 'when attribute is hidden in a group' do
+          before do
+            attribute.hidden_in_groups(:some_group)
+          end
+
+          it 'builds field with a given group' do
+            expect(field_options).to include(hidden_in_groups: %w[some_group])
+          end
+        end
+
         context 'when deprecation reason is set' do
           before do
             attribute.deprecated('I do not like it')

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -144,8 +144,8 @@ module GraphqlRails
             end
 
             it 'returns required input type', :aggregate_failures do
-              expect(input_argument_type.first.to_type_signature).to eq 'DummyModelInput'
-              expect(input_argument_type.second).to be_nil
+              expect(input_argument_type[0].to_type_signature).to eq 'DummyModelInput'
+              expect(input_argument_type[1]).to be_nil
             end
 
             it 'marks input as required' do
@@ -157,8 +157,8 @@ module GraphqlRails
             let(:type) { '[Int!]!' }
 
             it 'returns required input type', :aggregate_failures do
-              expect(input_argument_type.first.to_type_signature).to eq 'Int'
-              expect(input_argument_type.second).to be_nil
+              expect(input_argument_type[0].to_type_signature).to eq 'Int'
+              expect(input_argument_type[1]).to be_nil
             end
 
             it 'marks input as required' do
@@ -170,8 +170,8 @@ module GraphqlRails
             let(:type) { "[#{dummy_model.name}!]" }
 
             it 'contains required inner type', :aggregate_failures do
-              expect(input_argument_type.first.to_type_signature).to eq 'DummyModelInput'
-              expect(input_argument_type.second).to be_nil
+              expect(input_argument_type[0].to_type_signature).to eq 'DummyModelInput'
+              expect(input_argument_type[1]).to be_nil
             end
 
             it 'marks list part as not required' do
@@ -201,6 +201,16 @@ module GraphqlRails
 
           it 'builds field with a given group' do
             expect(input_argument_options).to include(groups: %w[some_group])
+          end
+        end
+
+        context 'when input is hidden in a groups' do
+          before do
+            attribute.hidden_in_groups(:some_group)
+          end
+
+          it 'builds field with a given group' do
+            expect(input_argument_options).to include(hidden_in_groups: %w[some_group])
           end
         end
 

--- a/spec/lib/graphql_rails/types/hidable_by_group_spec.rb
+++ b/spec/lib/graphql_rails/types/hidable_by_group_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GraphqlRails::Types::HidableByGroup do
+  subject(:dummy_type) { dummy_type_class.new(groups: groups, hidden_in_groups: hidden_in_groups) }
+
+  let(:dummy_class_parent) do
+    Class.new do
+      def visible?(_context)
+        true
+      end
+    end
+  end
+
+  let(:dummy_type_class) do
+    Class.new(dummy_class_parent) do
+      include GraphqlRails::Types::HidableByGroup
+    end
+  end
+
+  let(:groups) { [] }
+  let(:hidden_in_groups) { [] }
+
+  describe '#visible?' do
+    subject(:visible?) { dummy_type.visible?(graphql_context) }
+
+    let(:graphql_context) { { graphql_group: current_group } }
+    let(:current_group) { 'dummy' }
+
+    context 'when no groups are specified' do
+      it { is_expected.to be true }
+    end
+
+    context 'when groups are specified' do
+      context 'when current group is in groups' do
+        let(:groups) { [current_group] }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when current group is not in groups' do
+        let(:groups) { ['other_group'] }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when hidden_in_groups are specified' do
+      context 'when current group is in hidden_in_groups' do
+        let(:hidden_in_groups) { [current_group] }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when current group is not in hidden_in_groups' do
+        let(:hidden_in_groups) { ['other_group'] }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when groups and hidden_in_groups are specified' do
+      context 'when current group is in groups and hidden_in_groups' do
+        let(:groups) { [current_group] }
+        let(:hidden_in_groups) { [current_group] }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when current group is in groups and not in hidden_in_groups' do
+        let(:groups) { [current_group] }
+        let(:hidden_in_groups) { ['other_group'] }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when current group is not in groups and in hidden_in_groups' do
+        let(:groups) { ['other_group'] }
+        let(:hidden_in_groups) { [current_group] }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when current group is not in groups and not in hidden_in_groups' do
+        let(:groups) { ['other_group'] }
+        let(:hidden_in_groups) { ['other_group'] }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an attribute option called `hidden_in_groups`. As the name suggests, it makes field hidden in given groups.

Example:

```ruby
class User
  graphql do |c|
    c.attribute(:id).type('ID!').hidden_in_groups(:my_secret_group)
  end
end
```