### PR TITLE
Add `extras` config for attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 * Added: `hidden_in_groups` for attributes to be able to skip attribute from certain groups
+* Added: `extras` for attributes to be able to include graphql-ruby extensions
 
 ## [2.3.0](2022-11-25)
 

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -218,6 +218,21 @@ class User
     c.attribute :first_name, options: { attribute_name_format: :original } # will be accessible as first_name from client side
   end
 end
+```
+
+### attribute.extras
+
+Allows passing extras to enable [graphql-ruby field extensions](https://graphql-ruby.org/type_definitions/field_extensions.html#using-extras)
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    c.attribute(:items).extras([:lookahead])
+  end
+end
+```
 
 ### attribute.permit
 

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -43,7 +43,8 @@ module GraphqlRails
           camelize: camelize?,
           groups: groups,
           hidden_in_groups: hidden_in_groups,
-          **deprecation_reason_params
+          **deprecation_reason_params,
+          **extras_options
         }
       end
 
@@ -52,6 +53,12 @@ module GraphqlRails
       attr_reader :initial_name
 
       private
+
+      def extras_options
+        return {} if extras.empty?
+
+        { extras: extras }
+      end
 
       def camelize?
         options[:input_format] != :original && options[:attribute_name_format] != :original

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -17,6 +17,7 @@ module GraphqlRails
 
         chainable_option :description
         chainable_option :options, default: {}
+        chainable_option :extras, default: []
         chainable_option :type
       end
 

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -254,6 +254,16 @@ module GraphqlRails
             expect(field_options).to include(deprecation_reason: 'I do not like it')
           end
         end
+
+        context 'when extras are set' do
+          before do
+            attribute.extras([:lookahead])
+          end
+
+          it 'returns extras' do
+            expect(field_options).to include(extras: [:lookahead])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Adds `extras` option which allows to turn on features such as `lookahead`:

```ruby
class User
  graphql do |c|
    c.attribute(:orders).extras([:lookahead])
  end

  def orders(lookahead:)
    # do something
  end
end
```
