### PR TITLE
Include lookahead in controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 * Added: `hidden_in_groups` for attributes to be able to skip attribute from certain groups
 * Added: `extras` for attributes to be able to include graphql-ruby extensions
+* Added: `lookahead` as a controller request object field
 
 ## [2.3.0](2022-11-25)
 

--- a/lib/graphql_rails/controller/request.rb
+++ b/lib/graphql_rails/controller/request.rb
@@ -7,11 +7,12 @@ module GraphqlRails
       require 'graphql_rails/controller/request/format_errors'
 
       attr_accessor :object_to_return
-      attr_reader :errors, :context
+      attr_reader :errors, :context, :lookahead
 
       def initialize(graphql_object, inputs, context)
         @graphql_object = graphql_object
-        @inputs = inputs
+        @inputs = inputs.except(:lookahead)
+        @lookahead = inputs[:lookahead]
         @context = context
       end
 

--- a/lib/graphql_rails/router/route.rb
+++ b/lib/graphql_rails/router/route.rb
@@ -38,7 +38,7 @@ module GraphqlRails
         if function
           { function: function }
         else
-          { resolver: resolver }
+          { resolver: resolver, extras: [:lookahead] }
         end
       end
 

--- a/spec/lib/graphql_rails/controller/request_spec.rb
+++ b/spec/lib/graphql_rails/controller/request_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module GraphqlRails
+  RSpec.describe Controller::Request do
+    subject(:request) { described_class.new(graphql_object, inputs, context) }
+
+    let(:graphql_object) { double }
+    let(:inputs) { { id: 1, firstName: 'John' } }
+    let(:context) { double }
+
+    describe '#lookahead' do
+      subject(:lookahead) { request.lookahead }
+
+      context 'when inputs do not contain "lookahead" key' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when inputs contain "lookahead" key' do
+        let(:inputs) { { lookahead: 'some_value' } }
+
+        it 'returns value from inputs' do
+          expect(lookahead).to eq 'some_value'
+        end
+      end
+    end
+
+    describe '#params' do
+      subject(:params) { request.params }
+
+      it 'returns inputs' do
+        expect(params).to eq(inputs)
+      end
+
+      context 'when inputs contain "lookahead" key' do
+        let(:inputs) { { lookahead: 'some_value' } }
+
+        it 'returns inputs without lookahead key' do
+          expect(params).to eq({})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows accessing lookahead data in graphql controller:

```ruby
class UsersController < GraphqlController
  model('User')
  action(:show).returns_single

  def show
    users = User.all
    users = users.includes(:orders) if graphql_request.lookahead.selects?(:orders)
    users.find(params[:id])
  end
end
```
