### PR TITLE
Include dummy lookahead data into controller specs

### DIFF
--- a/lib/graphql_rails/rspec_controller_helpers.rb
+++ b/lib/graphql_rails/rspec_controller_helpers.rb
@@ -95,7 +95,9 @@ module GraphqlRails
     # controller request object more suitable for testing
     class Request < GraphqlRails::Controller::Request
       def initialize(params, context)
-        super(nil, params, context)
+        inputs = params || {}
+        inputs = inputs.merge(lookahead: ::GraphQL::Execution::Lookahead::NullLookahead.new)
+        super(nil, inputs, context)
       end
     end
 


### PR DESCRIPTION
We added `lookahead` data into the graphql_request object so you can access it from the controller. However, rspec helper was not updated, and in tests `graphql_request.lookahead` returns `nil` which does not happen in the actual controller. 

This PR adds a dummy lookahead instance to request which makes graphql_controller specs a bit more similar to the real-life cases.