### PR TITLE
Add Ruby 3.2 to CI, Upgrade Checkout Action - v2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,14 +3,15 @@ on: [push, pull_request]
 jobs:
   specs:
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     runs-on: ubuntu-latest
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ SimpleCov.start do
 end
 
 require 'graphql_rails'
-require 'pry'
 
 if ENV['CODECOV_TOKEN']
   require 'codecov'


### PR DESCRIPTION
This is an alternate version of my PR #261.  That PR had Ruby 2.7 failing, which appears to be a result of one of the dependency upgrades.  As those dependency upgrades aren't needed for the core changes - adding Ruby 3.2, upgrading the checkout action so that CI can continue to run, I rebuilt the PR without that.

Aside from code coverage, everything runs green on my fork.

cc: @povilasjurcys 