### PR TITLE
Add same_as attribute method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added: `input.attribute.property` method which allows aliasing input parameter keys
+* Added: possibility to copy attribute config using the `Attribute#same_as` method
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -368,6 +368,21 @@ class User
 end
 ```
 
+### attribute.same_as
+
+When you want to have identical attributes, you can use `Attribute#same_as` to make sure that attribute params will stay in sync:
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql do |c|
+    c.attribute(:user_id).type('ID').description('User ID')
+    c.attribute(:person_id).same_as(c.attribute(:user_id))
+  end
+end
+```
+
 ### attribute.with
 
 When you want to define some options dynamically, it's quite handy to use "Attribute#with" method:
@@ -613,6 +628,28 @@ class User
 
   graphql.input do |c|
     c.attribute(:is_admin).type('Boolean').default_value(false)
+  end
+end
+```
+
+#### input attribute config copy
+
+You can copy existing config from other attribute using `Attribute#same_as` method:
+
+```ruby
+class User
+  include GraphqlRails::Model
+
+  graphql.input(:create) do |c|
+    c.attribute(:first_name).type('String!')
+    c.attribute(:last_name).type('String!')
+  end
+
+  graphql.input(:update) do |c|
+    c.attribute(:id).type('ID!')
+    graphql.input(:contract).attributes.each_value do |attr|
+      c.attribute(attr.name).same_as(attr)
+    end
   end
 end
 ```

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -71,6 +71,16 @@ module GraphqlRails
         @property = new_value.to_s
         self
       end
+
+      def same_as(other_attribute)
+        other_attribute.dup.instance_variables.each do |instance_variable|
+          next if instance_variable == :@initial_name
+
+          instance_variable_set(instance_variable, other_attribute.instance_variable_get(instance_variable))
+        end
+
+        self
+      end
     end
   end
 end

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -62,6 +62,27 @@ module GraphqlRails
         end
       end
 
+      describe '#same_as' do
+        let(:other_attribute) { described_class.new(:other).with(type: 'Integer', description: 'other') }
+
+        it 'copies all attributes except name from existing attribute' do
+          expect(attribute.same_as(other_attribute)).to have_attributes(
+            name: 'full_name',
+            type: 'Integer',
+            description: 'other'
+          )
+        end
+
+        it 'keeps other attribute unchanged' do # rubocop:disable RSpec/ExampleLength
+          attribute.same_as(other_attribute)
+          expect(other_attribute).to have_attributes(
+            name: 'other',
+            type: 'Integer',
+            description: 'other'
+          )
+        end
+      end
+
       describe '#field_args' do
         subject(:field_args) { attribute.field_args }
 

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -67,6 +67,29 @@ module GraphqlRails
         end
       end
 
+      describe '#same_as' do
+        let(:other_attribute) do
+          described_class.new(:other, config: config).with(type: 'Integer', description: 'other')
+        end
+
+        it 'copies all attributes except name from existing attribute' do
+          expect(attribute.same_as(other_attribute)).to have_attributes(
+            name: 'full_name',
+            type: 'Integer',
+            description: 'other'
+          )
+        end
+
+        it 'keeps other attribute unchanged' do # rubocop:disable RSpec/ExampleLength
+          attribute.same_as(other_attribute)
+          expect(other_attribute).to have_attributes(
+            name: 'other',
+            type: 'Integer',
+            description: 'other'
+          )
+        end
+      end
+
       describe '#input_argument_args' do
         subject(:input_argument_args) { attribute.input_argument_args }
 


### PR DESCRIPTION
Copying attribute values from one attribute to another can be useful in certain situations. For instance, when you need to create alias methods or multiple input types that are similar. 

This pull request introduces a new method called `Attribute#same_as` that allows you to perform this operation.