### PR TITLE
Add input attribute aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added: `input.attribute.property` method which allows aliasing input parameter keys
+
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.4.0](2023-27-25)

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -588,7 +588,6 @@ class User
 end
 ```
 
-
 #### input attribute deprecation
 
 You can mark input attribute as deprecated with `deprecated` method:
@@ -615,6 +614,37 @@ class User
   graphql.input do |c|
     c.attribute(:is_admin).type('Boolean').default_value(false)
   end
+end
+```
+
+#### input attribute property
+
+Sometimes it's handy to have different input attribute on graphql level and different on controller. That's when `Attribute#property` comes to the rescue:
+
+```ruby
+class Post
+  include GraphqlRails::Model
+
+  graphql.input do |c|
+    c.attribute(:author_id).type('ID').property(:user_id)
+  end
+end
+```
+
+Then mutation such as:
+
+```gql
+mutation createPost(input: { authorId: 123 }) {
+  author
+}
+```
+
+Will pass `user_id` instead of `authorId` in controller:
+
+```ruby
+# posts_controller.rb
+def create
+  Post.create!(user_id: params[:input][:user_id])
 end
 ```
 

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -21,13 +21,6 @@ module GraphqlRails
         @attributes ||= {}
       end
 
-      def property(new_value = NOT_SET)
-        return @property if new_value == NOT_SET
-
-        @property = new_value.to_s
-        self
-      end
-
       def field_args
         [
           field_name,

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -64,6 +64,13 @@ module GraphqlRails
       def deprecation_reason
         @deprecation_reason
       end
+
+      def property(new_value = ChainableOptions::NOT_SET)
+        return @property if new_value == ChainableOptions::NOT_SET
+
+        @property = new_value.to_s
+        self
+      end
     end
   end
 end

--- a/lib/graphql_rails/attributes/input_attribute.rb
+++ b/lib/graphql_rails/attributes/input_attribute.rb
@@ -33,6 +33,7 @@ module GraphqlRails
           groups: groups,
           hidden_in_groups: hidden_in_groups,
           **default_value_option,
+          **property_params,
           **deprecation_reason_params
         }
       end
@@ -57,6 +58,10 @@ module GraphqlRails
 
       def deprecation_reason_params
         { deprecation_reason: deprecation_reason }.compact
+      end
+
+      def property_params
+        { as: property }.compact
       end
 
       def attribute_naming_options

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -60,6 +60,13 @@ module GraphqlRails
         end
       end
 
+      describe '#property' do
+        it 'changes property' do
+          expect { attribute.property('new_property') }
+            .to change(attribute, :property).to('new_property')
+        end
+      end
+
       describe '#input_argument_args' do
         subject(:input_argument_args) { attribute.input_argument_args }
 
@@ -231,6 +238,16 @@ module GraphqlRails
 
           it 'builds field with a given default value' do
             expect(input_argument_options).to include(default_value: 'some value')
+          end
+        end
+
+        context 'when input has property' do
+          before do
+            attribute.property('some_property')
+          end
+
+          it 'builds field with a given property' do
+            expect(input_argument_options).to include(as: 'some_property')
           end
         end
       end


### PR DESCRIPTION
This PR enables to add alias key to input attributes. This is handy during refactoring.

After this change:
```ruby
class Post
  include GraphqlRails::Model

  graphql.input do |c|
    c.attribute(:author_id).type('ID').property(:user_id)
  end
end
```

```gql
mutation createPost(input: { authorId: 123 }) {
  author
}
```

Will pass `user_id` instead of `authorId` in controller:

```ruby
# posts_controller.rb
def create
  params[:input] # => { user_id: 123 }
end
```