### PR TITLE
Fix same_as attribute name handling

### DIFF
--- a/lib/graphql_rails/attributes/attributable.rb
+++ b/lib/graphql_rails/attributes/attributable.rb
@@ -8,6 +8,11 @@ module GraphqlRails
     # contains methods which are shared between various attribute-like classes
     # expects `initial_name` and `type` to be defined
     module Attributable
+      def initialize_copy(_original)
+        super
+        @attribute_name_parser = nil
+      end
+
       def field_name
         attribute_name_parser.field_name
       end

--- a/lib/graphql_rails/attributes/attribute_configurable.rb
+++ b/lib/graphql_rails/attributes/attribute_configurable.rb
@@ -73,10 +73,11 @@ module GraphqlRails
       end
 
       def same_as(other_attribute)
-        other_attribute.dup.instance_variables.each do |instance_variable|
+        other = other_attribute.dup
+        other.instance_variables.each do |instance_variable|
           next if instance_variable == :@initial_name
 
-          instance_variable_set(instance_variable, other_attribute.instance_variable_get(instance_variable))
+          instance_variable_set(instance_variable, other.instance_variable_get(instance_variable))
         end
 
         self

--- a/spec/lib/graphql_rails/attributes/attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/attribute_spec.rb
@@ -65,6 +65,10 @@ module GraphqlRails
       describe '#same_as' do
         let(:other_attribute) { described_class.new(:other).with(type: 'Integer', description: 'other') }
 
+        before do
+          other_attribute.name # trigger instance variable initialization
+        end
+
         it 'copies all attributes except name from existing attribute' do
           expect(attribute.same_as(other_attribute)).to have_attributes(
             name: 'full_name',

--- a/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
+++ b/spec/lib/graphql_rails/attributes/input_attribute_spec.rb
@@ -72,6 +72,10 @@ module GraphqlRails
           described_class.new(:other, config: config).with(type: 'Integer', description: 'other')
         end
 
+        before do
+          other_attribute.name # trigger instance variable initialization
+        end
+
         it 'copies all attributes except name from existing attribute' do
           expect(attribute.same_as(other_attribute)).to have_attributes(
             name: 'full_name',


### PR DESCRIPTION
Currently, we have a bug when using `same_as` with the attribute that has a cached name (this happens, when we call `attribute.name`). As a result, the new attribute will inherit the name. This is incorrect. 

This PR improves the code, so the new attribute will have its own name even if the `same_as` attribute has cached the name