### PR TITLE
Add support for more pagination options and add missing documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added: `input.attribute.property` method which allows aliasing input parameter keys
 * Added: possibility to copy attribute config using the `Attribute#same_as` method
 * Fixed: do not ignore custom `max_page_size` for paginated responses
+* Fixed: do not ignore custom `default_page_size` and other options for paginated responses
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.4.0](2023-27-25)

--- a/docs/components/controller.md
+++ b/docs/components/controller.md
@@ -194,7 +194,21 @@ class UsersController < GraphqlRails::Controller
   action(:index).paginated(max_page_size: 10) # add max items limit
 
   def index
-    User.all # it will render 10 users even you have more
+    User.all # it will render max 10 users even you have requested more
+  end
+end
+```
+
+#### *default_page_size*
+
+Allows to specify max items count per request
+
+```ruby
+class UsersController < GraphqlRails::Controller
+  action(:index).paginated(default_page_size: 5) # add default items per page size
+
+  def index
+    User.all # it will render 5 users even you have more
   end
 end
 ```

--- a/lib/graphql_rails/attributes/attribute.rb
+++ b/lib/graphql_rails/attributes/attribute.rb
@@ -70,9 +70,7 @@ module GraphqlRails
       end
 
       def field_args_pagination_options
-        return {} unless paginated?
-
-        pagination_options.slice(:max_page_size)
+        pagination_options || {}
       end
     end
   end

--- a/lib/graphql_rails/router/route.rb
+++ b/lib/graphql_rails/router/route.rb
@@ -57,9 +57,7 @@ module GraphqlRails
 
       def resolver_options
         action_config = action.action_config
-        return {} unless action_config.paginated?
-
-        action_config.pagination_options.slice(:max_page_size)
+        action_config.pagination_options || {}
       end
     end
   end

--- a/spec/lib/graphql_rails/controller/configuration_spec.rb
+++ b/spec/lib/graphql_rails/controller/configuration_spec.rb
@@ -93,12 +93,15 @@ module GraphqlRails
 
       context 'when pagination options was set' do
         let(:define_actions) do
-          configuration.action(:some_method).paginated(max_page_size: 200).permit(:id)
+          configuration.action(:some_method)
+                       .paginated(max_page_size: 200, default_page_size: 10)
+                       .permit(:id)
           configuration.action(:some_other_method).permit(:id, :name)
         end
 
         it 'sets options only for given action', :aggregate_failures do
-          expect(configuration.action(:some_method).pagination_options).to eq(max_page_size: 200)
+          expect(configuration.action(:some_method).pagination_options)
+            .to eq(max_page_size: 200, default_page_size: 10)
           expect(configuration.action(:some_other_method).pagination_options).to be_nil
         end
       end

--- a/spec/lib/graphql_rails/router/route_spec.rb
+++ b/spec/lib/graphql_rails/router/route_spec.rb
@@ -19,7 +19,10 @@ module GraphqlRails
       end
 
       Class.new(GraphqlRails::Controller) do
-        action(:show).permit(:name!).returns(user_type).paginated(max_page_size: 100)
+        action(:show)
+          .permit(:name!)
+          .paginated(max_page_size: 100, default_page_size: 10)
+          .returns(user_type)
 
         def show
           'OK'
@@ -101,7 +104,8 @@ module GraphqlRails
       it 'returns correct options' do
         expect(field_options).to include(
           extras: [:lookahead],
-          max_page_size: 100
+          max_page_size: 100,
+          default_page_size: 10
         )
       end
     end


### PR DESCRIPTION
The previous fix fixed only the `max_page_size` bug. This PR fixes any other possible pagination option passing.