### PR TITLE
Do not crash when using deeply nested input definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added: possibility to copy attribute config using the `Attribute#same_as` method
 * Fixed: do not ignore custom `max_page_size` for paginated responses
 * Fixed: do not ignore custom `default_page_size` and other options for paginated responses
+* Fixed: do not crash when using deeply nested input definitions
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.4.0](2023-27-25)

--- a/lib/graphql_rails/model/find_or_build_graphql_input_type.rb
+++ b/lib/graphql_rails/model/find_or_build_graphql_input_type.rb
@@ -23,6 +23,14 @@ module GraphqlRails
           end
         end
       end
+
+      def find_or_build_dynamic_type(attribute)
+        graphql_model = attribute.graphql_model
+        return unless graphql_model
+
+        graphql = graphql_model.graphql.input(attribute.subtype)
+        find_or_build_graphql_model_type(graphql)
+      end
     end
   end
 end

--- a/lib/graphql_rails/model/find_or_build_graphql_type.rb
+++ b/lib/graphql_rails/model/find_or_build_graphql_type.rb
@@ -55,15 +55,17 @@ module GraphqlRails
 
       def find_or_build_dynamic_type(attribute)
         graphql_model = attribute.graphql_model
-        find_or_build_graphql_model_type(graphql_model) if graphql_model
+        return unless graphql_model
+
+        find_or_build_graphql_model_type(graphql_model.graphql)
       end
 
-      def find_or_build_graphql_model_type(graphql_model)
+      def find_or_build_graphql_model_type(graphql_config)
         self.class.call(
-          name: graphql_model.graphql.name,
-          description: graphql_model.graphql.description,
-          attributes: graphql_model.graphql.attributes,
-          type_name: graphql_model.graphql.type_name
+          name: graphql_config.name,
+          description: graphql_config.description,
+          attributes: graphql_config.attributes,
+          type_name: graphql_config.type_name
         )
       end
     end


### PR DESCRIPTION
Currently, graphql crashes when we use nested input types. This PR fixes the issue