### PR TITLE
Add `rescue_from` support in controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed: do not ignore custom `max_page_size` for paginated responses
 * Fixed: do not ignore custom `default_page_size` and other options for paginated responses
 * Fixed: do not crash when using deeply nested input definitions
+* Added: `rescue_from` support in controllers
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.4.0](2023-27-25)

--- a/lib/graphql_rails/controller/configuration.rb
+++ b/lib/graphql_rails/controller/configuration.rb
@@ -13,7 +13,7 @@ module GraphqlRails
 
       LIB_REGEXP = %r{/graphql_rails/lib/}
 
-      attr_reader :action_by_name
+      attr_reader :action_by_name, :error_handlers
 
       def initialize(controller)
         @controller = controller
@@ -25,6 +25,7 @@ module GraphqlRails
 
         @action_by_name = {}
         @action_default = nil
+        @error_handlers = {}
       end
 
       def initialize_copy(other)
@@ -54,6 +55,10 @@ module GraphqlRails
 
         hooks[hook_type][hook_key] = \
           ActionHook.new(name: hook_name, **options, &block)
+      end
+
+      def add_error_handler(error, with:, &block)
+        @error_handlers[error] = with || block
       end
 
       def action_default

--- a/lib/graphql_rails/controller/handle_controller_error.rb
+++ b/lib/graphql_rails/controller/handle_controller_error.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module GraphqlRails
+  class Controller
+    # runs {before/around/after}_action controller hooks
+    class HandleControllerError
+      def initialize(error:, controller:)
+        @error = error
+        @controller = controller
+      end
+
+      def call
+        return custom_handle_error if custom_handle_error?
+
+        render_unhandled_error(error)
+      end
+
+      private
+
+      attr_reader :error, :controller
+
+      def render_unhandled_error(error)
+        return render(error: error) if error.is_a?(GraphQL::ExecutionError)
+
+        render(error: SystemError.new(error))
+      end
+
+      def custom_handle_error
+        return unless custom_handler
+
+        begin
+          if custom_handler.is_a?(Proc)
+            controller.instance_exec(error, &custom_handler)
+          else
+            controller.send(custom_handler)
+          end
+        rescue StandardError => e
+          render_unhandled_error(e)
+        end
+      end
+
+      def custom_handler
+        return @custom_handler if defined?(@custom_handler)
+
+        handler = controller_config.error_handlers.detect do |error_class, _handler|
+          error.class <= error_class
+        end
+
+        @custom_handler = handler&.last
+      end
+
+      def custom_handle_error?
+        custom_handler.present?
+      end
+
+      def controller_config
+        @controller_config ||= controller.class.controller_configuration
+      end
+
+      def render(*args, **kwargs, &block)
+        controller.send(:render, *args, **kwargs, &block)
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_rails/controller/handle_controller_error_spec.rb
+++ b/spec/lib/graphql_rails/controller/handle_controller_error_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe GraphqlRails::Controller::HandleControllerError do
+  describe '#call' do
+    subject(:call) { described_class.new(error: error, controller: controller).call }
+
+    let(:controller_class) do
+      Class.new(GraphqlRails::Controller)
+    end
+    let(:controller) { controller_class.new(graphql_request) }
+    let(:graphql_request) { GraphqlRails::Controller::Request.new(graphql_object, inputs, context) }
+    let(:graphql_object) { double }
+    let(:inputs) { { id: 1, firstName: 'John' } }
+    let(:context) { double(add_error: nil) } # rubocop:disable RSpec/VerifiedDoubles
+
+    let(:error) { StandardError.new('error') }
+
+    before do
+      allow(controller).to receive(:render).and_call_original
+    end
+
+    context 'when error is a GraphQL::ExecutionError' do
+      let(:error) { GraphQL::ExecutionError.new('error') }
+
+      it 'renders error' do
+        call
+
+        expect(controller).to have_received(:render).with(error: error)
+      end
+    end
+
+    context 'when error is not a GraphQL::ExecutionError' do
+      it 'renders SystemError' do
+        call
+
+        expect(controller).to have_received(:render).with(error: GraphqlRails::SystemError.new(error))
+      end
+    end
+
+    context 'when controller has custom error handler' do
+      let(:handled_error_class) { Class.new(StandardError) }
+      let(:error_class) { handled_error_class }
+      let(:error) { error_class.new('error') }
+
+      context 'when custom handler is a block' do
+        let(:controller_class) do
+          error_to_handle = handled_error_class
+
+          Class.new(super()) do
+            rescue_from(error_to_handle) { |error| render(error: error.message) }
+          end
+        end
+
+        it 'renders error' do
+          call
+
+          expect(controller).to have_received(:render).with(error: error.message)
+        end
+      end
+
+      context 'when custom handler is a method' do
+        let(:controller_class) do
+          error_to_handle = handled_error_class
+
+          Class.new(super()) do
+            rescue_from error_to_handle, with: :custom_handler
+
+            def custom_handler
+              render(error: 'custom error')
+            end
+          end
+        end
+
+        it 'renders error' do
+          call
+
+          expect(controller).to have_received(:render).with(error: 'custom error')
+        end
+      end
+
+      context 'when custom handler raises error' do
+        let(:controller_class) do
+          error_to_handle = handled_error_class
+
+          Class.new(super()) do
+            rescue_from(error_to_handle) { |error| raise error }
+          end
+        end
+
+        it 'renders SystemError' do
+          call
+
+          expect(controller).to have_received(:render).with(error: GraphqlRails::SystemError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows handling graphql errors using `rescue_from` hook same way as in RoR controllers:

```ruby
class MyController < GraphqlRails::Controller
  rescue_from MyError, with:  :custom_handle

  private

  def custom_handle(error)
    render error: "custom_error: #{error.message)"
  end
end
```