### PR TITLE
Add `implements` support for models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed: do not crash when using deeply nested input definitions
 * Added: `rescue_from` support in controllers
 * Added: Bumped graphql version to 2.1.7
+* Added: `implements` support in models
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
-## [2.4.0](2023-27-25)
+## [2.4.0](2023-11-25)
 
 * Added: `hidden_in_groups` for attributes to be able to skip attribute from certain groups
 * Added: `extras` for attributes to be able to include graphql-ruby extensions

--- a/docs/components/model.md
+++ b/docs/components/model.md
@@ -462,6 +462,30 @@ class User
 end
 ```
 
+## implements
+
+`implements` indicates that graphql type implements one or more interfaces:
+
+```ruby
+module UserInterface
+  include GraphQL::Schema::Interface
+  # ....
+end
+
+module AdvancedUserInterface
+  include GraphQL::Schema::Interface
+  # ...
+end
+
+class AdminUser
+  include GraphqlRails::Model
+
+  graphql do |c|
+    c.implements(UserInterface, AdvancedUserInterface)
+  end
+end
+```
+
 ## graphql_type
 
 Sometimes it's handy to get raw graphql type. To do so you can call:

--- a/lib/graphql_rails/attributes/type_parseable.rb
+++ b/lib/graphql_rails/attributes/type_parseable.rb
@@ -94,9 +94,9 @@ module GraphqlRails
       end
 
       def graphql_type_object?(type_class)
-        return false unless type_class.is_a?(Class)
+        return false if !type_class.is_a?(Class) && !type_class.is_a?(Module)
 
-        type_class < GraphQL::Schema::Member
+        type_class < GraphQL::Schema::Member::GraphQLTypeNames
       end
 
       def applicable_graphql_type?(type)

--- a/lib/graphql_rails/model/configuration.rb
+++ b/lib/graphql_rails/model/configuration.rb
@@ -24,6 +24,15 @@ module GraphqlRails
         @input = other.instance_variable_get(:@input)&.transform_values(&:dup)
       end
 
+      def implements(*interfaces)
+        previous_implements = get_or_set_chainable_option(:implements) || []
+        return previous_implements if interfaces.blank?
+
+        full_implements = (previous_implements + interfaces).uniq
+
+        get_or_set_chainable_option(:implements, full_implements) || []
+      end
+
       def attribute(attribute_name, **attribute_options)
         key = attribute_name.to_s
 
@@ -52,7 +61,8 @@ module GraphqlRails
           name: name,
           description: description,
           attributes: attributes,
-          type_name: type_name
+          type_name: type_name,
+          implements: implements
         )
       end
 
@@ -86,6 +96,7 @@ module GraphqlRails
           description: description,
           attributes: attributes,
           type_name: type_name,
+          implements: implements,
           force_define_attributes: true
         )
       end

--- a/lib/graphql_rails/model/find_or_build_graphql_type_class.rb
+++ b/lib/graphql_rails/model/find_or_build_graphql_type_class.rb
@@ -9,12 +9,13 @@ module GraphqlRails
 
       include ::GraphqlRails::Service
 
-      def initialize(name:, type_name:, parent_class:, description: nil)
+      def initialize(name:, type_name:, parent_class:, description: nil, implements: [])
         @name = name
         @type_name = type_name
         @description = description
         @new_class = false
         @parent_class = parent_class
+        @implements = implements
       end
 
       def klass
@@ -28,15 +29,17 @@ module GraphqlRails
       private
 
       attr_accessor :new_class
-      attr_reader :name, :type_name, :description, :parent_class
+      attr_reader :name, :type_name, :description, :parent_class, :implements
 
       def build_graphql_type_klass
         graphql_type_name = name
         graphql_type_description = description
+        interfaces = implements
 
         graphql_type_klass = Class.new(parent_class) do
           graphql_name(graphql_type_name)
           description(graphql_type_description)
+          interfaces.each { |interface| implements(interface) }
         end
 
         self.new_class = true

--- a/spec/lib/graphql_rails/attributes/type_parser_spec.rb
+++ b/spec/lib/graphql_rails/attributes/type_parser_spec.rb
@@ -242,6 +242,19 @@ module GraphqlRails
           it { is_expected.to be GraphQL::Types::Float }
         end
 
+        context 'when attribute is interface' do
+          let(:type) do
+            Module.new do
+              include GraphQL::Schema::Interface
+              graphql_name 'SomeInterface'
+            end
+          end
+
+          it 'returns interface' do
+            expect(graphql_type).to be(type)
+          end
+        end
+
         context 'when attribute is not supported' do
           let(:type) { 'unknown' }
 

--- a/spec/lib/graphql_rails/model/configuration_spec.rb
+++ b/spec/lib/graphql_rails/model/configuration_spec.rb
@@ -250,5 +250,33 @@ module GraphqlRails
         end
       end
     end
+
+    describe '#implements' do
+      it 'returns empty array by default' do
+        expect(config.implements).to eq []
+      end
+
+      context 'when called with arguments' do
+        it 'changes implements to a given value' do
+          interfaces = [GraphQL::Types::Relay::Node]
+          expect { config.implements(*interfaces) }.to change(config, :implements).to(interfaces)
+        end
+      end
+
+      context 'when implements with arguments is called second time' do
+        let(:existing_interfaces) { [GraphQL::Types::Relay::Node] }
+
+        before do
+          config.implements(*existing_interfaces)
+        end
+
+        it 'extends existing implements' do
+          new_interfaces = [:SomeInterface]
+          expect { config.implements(*new_interfaces) }
+            .to change(config, :implements)
+            .to(existing_interfaces + new_interfaces)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/graphql_rails/model/find_or_build_graphql_type_class_spec.rb
+++ b/spec/lib/graphql_rails/model/find_or_build_graphql_type_class_spec.rb
@@ -10,13 +10,15 @@ module GraphqlRails
           name: name,
           type_name: type_name,
           description: description,
-          parent_class: GraphQL::Schema::Object
+          parent_class: GraphQL::Schema::Object,
+          implements: implements
         )
       end
 
       let(:name) { 'DummyModel' }
       let(:type_name) { 'DummyModelType' }
       let(:description) { 'DummyModelTypeDescription' }
+      let(:implements) { [] }
 
       describe '#klass' do
         subject(:klass) { graphql_type_finder.klass }


### PR DESCRIPTION
This PR adds basic interface support for GraphqlRails::Model.

Usage:
```ruby
module VisitorInterface
  include GraphQL::Schema::Interface
  
  field :failed_logins_count, Integer
end

class UserDecorator
  include GraphqlRails::Model

  graphql do |c|
    c.implements(VisitorInterface)
    # ...
  end
end
```
