### PR TITLE
Include controller and action name in response when using RSpecControllerHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added: `rescue_from` support in controllers
 * Added: Bumped graphql version to 2.1.7
 * Added: `implements` support in models
+* Added: `response.controller` and `response.action_name` methods in RSpecControllerHelpers
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.4.0](2023-11-25)

--- a/lib/graphql_rails/controller/log_controller_action.rb
+++ b/lib/graphql_rails/controller/log_controller_action.rb
@@ -7,6 +7,7 @@ module GraphqlRails
     # logs controller start and end times
     class LogControllerAction
       require 'graphql_rails/concerns/service'
+      require 'active_support/notifications'
 
       include ::GraphqlRails::Service
 

--- a/spec/lib/graphql_rails/rspec_controller_helpers_spec.rb
+++ b/spec/lib/graphql_rails/rspec_controller_helpers_spec.rb
@@ -86,6 +86,16 @@ module GraphqlRails
     end
 
     describe '#response' do
+      it 'includes controller name' do
+        runner.query(:index, params: action_params, context: action_context)
+        expect(runner.response.controller).to eq TestableController
+      end
+
+      it 'includes action name' do
+        runner.query(:index, params: action_params, context: action_context)
+        expect(runner.response.action_name).to eq :index
+      end
+
       context 'when request was successful' do
         it 'sets status to success' do
           runner.query(:index, params: action_params, context: action_context)


### PR DESCRIPTION
Added `controller` and `action_name` methods to `Response` object which is used in RSpec tests only. I do not expect it to be used widely but it should be quite useful for other tools such as graphql type validators I'm working on here: https://github.com/povilasjurcys/rspec-extra_matchers