### PR TITLE
Stop supporting ruby<3.0.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
     runs-on: ubuntu-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added: Bumped graphql version to 2.1.7
 * Added: `implements` support in models
 * Added: `response.controller` and `response.action_name` methods in RSpecControllerHelpers
+* Removed: stop supporting ruby < 3.0.0
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [2.4.0](2023-11-25)


### PR DESCRIPTION
Some libraries that we use no longer support ruby 2.7. For this reason we can't get newest security updates. This PR drops ruby 2.7 support