### PR TITLE
Better handle render in controller hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
+* Fixed: Stop processing hooks and controller action if graphql_request has errors
 
 ## [3.0.0](2024-05-31)
 

--- a/lib/graphql_rails/controller.rb
+++ b/lib/graphql_rails/controller.rb
@@ -89,7 +89,7 @@ module GraphqlRails
     private
 
     def call_with_rendering
-      hooks_runner = ActionHooksRunner.new(action_name: action_name, controller: self)
+      hooks_runner = ActionHooksRunner.new(action_name: action_name, controller: self, graphql_request: graphql_request)
       response = hooks_runner.call { public_send(action_name) }
 
       render response if graphql_request.no_object_to_return?

--- a/lib/graphql_rails/controller/request.rb
+++ b/lib/graphql_rails/controller/request.rb
@@ -14,6 +14,7 @@ module GraphqlRails
         @inputs = inputs.except(:lookahead)
         @lookahead = inputs[:lookahead]
         @context = context
+        @errors = []
       end
 
       def errors=(new_errors)

--- a/spec/lib/graphql_rails/controller/action_hooks_runner_spec.rb
+++ b/spec/lib/graphql_rails/controller/action_hooks_runner_spec.rb
@@ -23,12 +23,19 @@ module GraphqlRails
         end
       end
 
-      subject(:runner) { described_class.new(action_name: action_name, controller: controller) }
+      subject(:runner) do
+        described_class.new(
+          action_name: action_name,
+          controller: controller,
+          graphql_request: graphql_request
+        )
+      end
 
       let(:action_name) { :some_action }
       let(:controller) { double('Controller') } # rubocop:disable RSpec/VerifiedDoubles
       let(:controller_class) { class_double(Controller) }
       let(:controller_configuration) { Controller::Configuration.new(controller) }
+      let(:graphql_request) { GraphqlRails::Controller::Request.new(nil, {}, {}) }
 
       before do
         allow(controller).to receive(:class).and_return(controller_class)


### PR DESCRIPTION
The controller processes the action even though a hook renders the error. This is incorrect.

This PR fixes the issue by stopping processing the action if an error is present.

