### PR TITLE
Allow passing custom decorator build strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
+* Added: Option to create decorator instances with custom method passed by
 * Fixed: Stop processing hooks and controller action if graphql_request has errors
 
 ## [3.0.0](2024-05-31)

--- a/docs/components/decorator.md
+++ b/docs/components/decorator.md
@@ -25,7 +25,7 @@ class CommentDecorator < SimpleDelegator
 end
 ```
 
-In order to decorate object with exra arguments, simply pass them to `.decorate` method. Like this:
+In order to decorate object with extra arguments, simply pass them to `.decorate` method. Like this:
 
 ```ruby
 CommentDecorator.decorate(comment, current_user)
@@ -64,6 +64,36 @@ class UsersController < GraphqlRails::Controller
   def create
     user = User.create(params)
     UserDecorator.decorate(user)
+  end
+end
+```
+
+## Decorating with custom method
+
+Sometimes building decorator instance is not that straight-forward and you need to use custom build strategy. In such cases you can pass `build_with: :DESIRED_CLASS_METHOD` option:
+
+```ruby
+class UserDecorator < SimpleDelegator
+  include GraphqlRails::Model
+  include GraphqlRails::Decorator
+  # ...
+
+  def self.custom_build(user)
+    user.admin? ? new(user, admin: true) : new(user)
+  end
+
+  def initialize(user, admin: false)
+    @user = user
+    @admin = admin
+  end
+end
+
+class UsersController < GraphqlRails::Controller
+  action(:index).paginated.returns('[UserDecorator!]!')
+
+  def index
+    users = User.where(active: true)
+    UserDecorator.decorate(user, build_with: :custom_build)
   end
 end
 ```

--- a/lib/graphql_rails/decorator.rb
+++ b/lib/graphql_rails/decorator.rb
@@ -25,23 +25,27 @@ module GraphqlRails
     extend ActiveSupport::Concern
 
     class_methods do
-      def decorate(object, *args, **kwargs)
+      def decorate(object, *args, build_with: :new, **kwargs)
         if Decorator::RelationDecorator.decorates?(object)
-          decorate_with_relation_decorator(object, args, kwargs)
+          decorate_with_relation_decorator(object, args, kwargs, build_with: build_with)
         elsif object.nil?
           nil
         elsif object.is_a?(Array)
-          object.map { |item| new(item, *args, **kwargs) }
+          object.map { |item| public_send(build_with, item, *args, **kwargs) }
         else
-          new(object, *args, **kwargs)
+          public_send(build_with, object, *args, **kwargs)
         end
       end
 
       private
 
-      def decorate_with_relation_decorator(object, args, kwargs)
+      def decorate_with_relation_decorator(object, args, kwargs, build_with:)
         Decorator::RelationDecorator.new(
-          relation: object, decorator: self, decorator_args: args, decorator_kwargs: kwargs
+          relation: object,
+          decorator: self,
+          decorator_args: args,
+          decorator_kwargs: kwargs,
+          build_with: build_with
         )
       end
     end

--- a/lib/graphql_rails/decorator/relation_decorator.rb
+++ b/lib/graphql_rails/decorator/relation_decorator.rb
@@ -12,11 +12,12 @@ module GraphqlRails
           defined?(Mongoid) && object.is_a?(Mongoid::Criteria)
       end
 
-      def initialize(decorator:, relation:, decorator_args: [], decorator_kwargs: {})
+      def initialize(decorator:, relation:, decorator_args: [], decorator_kwargs: {}, build_with: :new)
         @relation = relation
         @decorator = decorator
         @decorator_args = decorator_args
         @decorator_kwargs = decorator_kwargs
+        @build_with = build_with
       end
 
       %i[where limit order group offset from select having all unscope].each do |method_name|
@@ -38,12 +39,12 @@ module GraphqlRails
       end
 
       def to_a
-        @to_a ||= relation.to_a.map { |it| decorator.new(it, *decorator_args, **decorator_kwargs) }
+        @to_a ||= relation.to_a.map { |it| build_decorator(it, *decorator_args, **decorator_kwargs) }
       end
 
       private
 
-      attr_reader :relation, :decorator, :decorator_args, :decorator_kwargs
+      attr_reader :relation, :decorator, :decorator_args, :decorator_kwargs, :build_with
 
       def decoratable_object_method(method_name, *args, **kwargs, &block)
         object = relation.public_send(method_name, *args, **kwargs, &block)
@@ -54,10 +55,14 @@ module GraphqlRails
         return object_or_list if object_or_list.blank?
 
         if object_or_list.is_a?(Array)
-          object_or_list.map { |it| decorator.new(it, *decorator_args, **decorator_kwargs) }
+          object_or_list.map { |it| build_decorator(it, *decorator_args, **decorator_kwargs) }
         else
-          decorator.new(object_or_list, *decorator_args, **decorator_kwargs)
+          build_decorator(object_or_list, *decorator_args, **decorator_kwargs)
         end
+      end
+
+      def build_decorator(...)
+        decorator.public_send(build_with, ...)
       end
 
       def decoratable_block_method(method_name, *args, **kwargs)
@@ -71,7 +76,8 @@ module GraphqlRails
         new_relation = relation.public_send(method_name, *args, **kwargs, &block)
         self.class.new(
           decorator: decorator, relation: new_relation,
-          decorator_args: decorator_args, decorator_kwargs: decorator_kwargs
+          decorator_args: decorator_args, decorator_kwargs: decorator_kwargs,
+          build_with: build_with
         )
       end
     end

--- a/lib/graphql_rails/decorator/relation_decorator.rb
+++ b/lib/graphql_rails/decorator/relation_decorator.rb
@@ -61,8 +61,8 @@ module GraphqlRails
         end
       end
 
-      def build_decorator(...)
-        decorator.public_send(build_with, ...)
+      def build_decorator(*args, **kwargs, &block)
+        decorator.public_send(build_with, *args, **kwargs, &block)
       end
 
       def decoratable_block_method(method_name, *args, **kwargs)

--- a/spec/lib/graphql_rails/decorator_spec.rb
+++ b/spec/lib/graphql_rails/decorator_spec.rb
@@ -15,6 +15,10 @@ module GraphqlRails
           'DummyDecorator'
         end
 
+        def self.custom_build(object, *args)
+          new(object, :custom, *args)
+        end
+
         def initialize(object, *args)
           @object = object
           @args = args
@@ -39,6 +43,16 @@ module GraphqlRails
 
         it 'creates decorator with given args' do
           expect(decorate.args).to eq(decorator_args)
+        end
+      end
+
+      context 'when custom build method is provided' do
+        subject(:decorate) { decorator_class.decorate(object, *decorator_args, build_with: :custom_build) }
+
+        let(:decorator_args) { %w[arg1 arg2] }
+
+        it 'uses custom build method' do
+          expect(decorate.args).to eq([:custom] + decorator_args)
         end
       end
 


### PR DESCRIPTION
This PR allows to customize how decorator instances are build. This allows more advanced strategies or building decorators from multiple objects