### PR TITLE
Reduce memory allocations when defining attributes

### DIFF
--- a/lib/graphql_rails/concerns/service.rb
+++ b/lib/graphql_rails/concerns/service.rb
@@ -8,11 +8,7 @@ module GraphqlRails
 
     class_methods do
       def call(*args, **kwargs, &block)
-        if kwargs.present?
-          new(*args, **kwargs).call(&block)
-        else
-          new(*args).call(&block)
-        end
+        new(*args, **kwargs).call(&block)
       end
     end
   end

--- a/lib/graphql_rails/model/add_fields_to_graphql_type.rb
+++ b/lib/graphql_rails/model/add_fields_to_graphql_type.rb
@@ -6,6 +6,7 @@ module GraphqlRails
     class AddFieldsToGraphqlType
       require 'graphql_rails/concerns/service'
       require 'graphql_rails/model/call_graphql_model_method'
+      require 'graphql_rails/model/direct_field_resolver'
 
       include ::GraphqlRails::Service
 
@@ -31,7 +32,7 @@ module GraphqlRails
           end
 
           define_method(attribute.field_name) do |**kwargs|
-            CallGraphqlModelMethod.call(
+            DirectFieldResolver.call(
               model: object,
               attribute_config: attribute,
               method_keyword_arguments: kwargs,

--- a/lib/graphql_rails/model/direct_field_resolver.rb
+++ b/lib/graphql_rails/model/direct_field_resolver.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module GraphqlRails
+  module Model
+    # Takes shortcuts for simple cases to minimize allocations
+    class DirectFieldResolver
+      class << self
+        def call(model:, attribute_config:, method_keyword_arguments:, graphql_context:)
+          property = attribute_config.property
+
+          if method_keyword_arguments.empty? && !attribute_config.paginated?
+            return simple_resolver(model: model, graphql_context: graphql_context, property: property)
+          end
+
+          CallGraphqlModelMethod.call(
+            model: model,
+            attribute_config: attribute_config,
+            method_keyword_arguments: method_keyword_arguments,
+            graphql_context: graphql_context
+          )
+        end
+
+        def simple_resolver(model:, graphql_context:, property:)
+          return model.send(property) unless model.respond_to?(:with_graphql_context)
+
+          model.with_graphql_context(graphql_context) { model.send(property) }
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql_rails/router.rb
+++ b/lib/graphql_rails/router.rb
@@ -12,7 +12,7 @@ module GraphqlRails
   # graphql router that mimics Rails.application.routes
   class Router
     RAW_ACTION_NAMES = %i[
-      use rescue_from query_analyzer instrument cursor_encoder default_max_page_size tracer
+      use rescue_from query_analyzer instrument cursor_encoder default_max_page_size tracer trace_with
     ].freeze
 
     def self.draw(&block)

--- a/spec/lib/graphql_rails/concerns/service_spec.rb
+++ b/spec/lib/graphql_rails/concerns/service_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module GraphqlRails
+  RSpec.describe Service do
+    let(:service_class) do
+      Class.new do
+        include GraphqlRails::Service
+
+        attr_reader :args, :kwargs
+
+        def initialize(*args, **kwargs)
+          @args = args
+          @kwargs = kwargs
+        end
+
+        def call
+          { args: args, kwargs: kwargs }
+        end
+      end
+    end
+
+    describe '.call' do
+      it 'instantiates service and calls instance method' do
+        result = service_class.call('arg1', 'arg2', key1: 'value1', key2: 'value2')
+        expect(result).to eq(args: %w[arg1 arg2], kwargs: { key1: 'value1', key2: 'value2' })
+      end
+
+      it 'works with empty kwargs' do
+        result = service_class.call('arg1', 'arg2')
+        expect(result).to eq(args: %w[arg1 arg2], kwargs: {})
+      end
+
+      it 'passes block to instance call method' do
+        service_instance = instance_double(service_class)
+        allow(service_class).to receive(:new).and_return(service_instance)
+        allow(service_instance).to receive(:call).and_yield
+        expect { |block| service_class.call(&block) }.to yield_control
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_rails/model/direct_field_resolver_spec.rb
+++ b/spec/lib/graphql_rails/model/direct_field_resolver_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module GraphqlRails
+  module Model
+    RSpec.describe DirectFieldResolver do
+      subject(:call) do
+        described_class.call(
+          model: model_instance,
+          attribute_config: attribute_config,
+          method_keyword_arguments: method_keyword_arguments,
+          graphql_context: graphql_context
+        )
+      end
+
+      let(:model_instance) { model.new }
+      let(:model) do
+        Class.new do
+          include GraphqlRails::Model
+
+          graphql do |c|
+            c.description 'Used for test purposes'
+            c.attribute :simple_property
+            c.attribute :context_aware_property
+            c.attribute :paginated_property, paginated: true
+            c.attribute :with_args_property, permit: { arg1: :string }
+          end
+
+          def self.name
+            'DummyModel'
+          end
+
+          def simple_property
+            'simple value'
+          end
+
+          def context_aware_property
+            graphql_context[:value]
+          end
+
+          def paginated_property
+            'paginated value'
+          end
+
+          def with_args_property(arg1: 'default')
+            arg1
+          end
+
+          def with_graphql_context(context)
+            @graphql_context = context
+            result = yield
+            @graphql_context = nil
+            result
+          end
+
+          private
+
+          def graphql_context
+            @graphql_context || {}
+          end
+        end
+      end
+
+      let(:attribute_config) { model.graphql.attributes['simple_property'] }
+      let(:graphql_context) { { value: 'context value' } }
+      let(:method_keyword_arguments) { {} }
+
+      describe '#call' do
+        context 'when method is simple with no arguments and not paginated' do
+          it 'uses simple_resolver' do
+            expect(call).to eq 'simple value'
+          end
+
+          it 'does not call CallGraphqlModelMethod' do
+            allow(CallGraphqlModelMethod).to receive(:call)
+            call
+            expect(CallGraphqlModelMethod).not_to have_received(:call)
+          end
+        end
+
+        context 'when method needs graphql context' do
+          let(:attribute_config) { model.graphql.attributes['context_aware_property'] }
+
+          it 'passes the context correctly' do
+            expect(call).to eq 'context value'
+          end
+        end
+
+        context 'when method is paginated' do
+          let(:attribute_config) { model.graphql.attributes['paginated_property'] }
+
+          before do
+            allow(CallGraphqlModelMethod).to receive(:call).and_call_original
+
+            call
+          end
+
+          it 'falls back to CallGraphqlModelMethod and works correctly' do
+            expect(CallGraphqlModelMethod).to have_received(:call).with(
+              model: model_instance, attribute_config: attribute_config,
+              method_keyword_arguments: method_keyword_arguments, graphql_context: graphql_context
+            )
+          end
+        end
+
+        context 'when method has arguments' do
+          let(:attribute_config) { model.graphql.attributes['with_args_property'] }
+          let(:method_keyword_arguments) { { arg1: 'custom value' } }
+
+          before do
+            allow(CallGraphqlModelMethod).to receive(:call).and_call_original
+
+            call
+          end
+
+          it 'falls back to CallGraphqlModelMethod and passes arguments correctly' do
+            expect(CallGraphqlModelMethod).to have_received(:call).with(
+              model: model_instance, attribute_config: attribute_config,
+              method_keyword_arguments: method_keyword_arguments, graphql_context: graphql_context
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reduces object allocations by improving the way attributes are resolved. On massive collections (where each item essentially has same attributes) this will yield to around 20% less object allocations.