### PR TITLE
Do not crash in tests when raising GraphQL::ExecutionError

### DIFF
--- a/lib/graphql_rails/controller.rb
+++ b/lib/graphql_rails/controller.rb
@@ -13,6 +13,8 @@ module GraphqlRails
   # base class for all graphql_rails controllers
   class Controller
     class << self
+      attr_accessor :error_handler
+
       def inherited(subclass)
         super
         new_config = controller_configuration.dup_with(controller: subclass)
@@ -94,7 +96,8 @@ module GraphqlRails
 
       render response if graphql_request.no_object_to_return?
     rescue StandardError => e
-      HandleControllerError.new(error: e, controller: self).call
+      error_handler = self.class.error_handler || HandleControllerError
+      error_handler.call(error: e, controller: self)
     end
 
     def graphql_errors_from_render_params(rendering_params)

--- a/lib/graphql_rails/controller/handle_controller_error.rb
+++ b/lib/graphql_rails/controller/handle_controller_error.rb
@@ -4,6 +4,10 @@ module GraphqlRails
   class Controller
     # runs {before/around/after}_action controller hooks
     class HandleControllerError
+      def self.call(error:, controller:)
+        new(error: error, controller: controller).call
+      end
+
       def initialize(error:, controller:)
         @error = error
         @controller = controller
@@ -20,9 +24,13 @@ module GraphqlRails
       attr_reader :error, :controller
 
       def render_unhandled_error(error)
-        raise error if error.is_a?(GraphQL::ExecutionError)
+        handle_graphql_execution_error(error) if error.is_a?(GraphQL::ExecutionError)
 
         render(error: SystemError.new(error))
+      end
+
+      def handle_graphql_execution_error(error)
+        raise error
       end
 
       def custom_handle_error


### PR DESCRIPTION
After the recent change, controller tests started to raise errors. This is not good, as controller errors should be tested via response/request objects and not be raised directly